### PR TITLE
Translate producer-consumer from Golang to Python

### DIFF
--- a/src/setup/deployment/raw-code/functions/producer-consumer/aws1.py
+++ b/src/setup/deployment/raw-code/functions/producer-consumer/aws1.py
@@ -1,0 +1,47 @@
+import os
+import boto3
+import boto3.session
+import json
+
+sessionInstance = None
+
+def invokeNextFunctionAWS(paramters, functionID):
+	namingPrefix = 'vHive-bench_'
+	
+	nextFunctionPayload = json.dumps(parameters)
+	print(f"Invoking next function: {namingPrefix}{functionID}")
+
+	lambdaClient = autheticateLambdaClient()
+
+	response = lambdaClient.invoke(
+        FunctionName=f"{namingPrefix}{functionID}",
+        InvocationType="RequestResponse",
+		LogType="Tail",
+        Payload=bytes(nextFunctionPayload, encoding="utf-8"),
+    )
+
+	# Steaming body, .read() or json.load() if expecting json response
+	return response["Payload"]
+
+def createSessionInstance():
+
+	region = os.environ['AWS_REGION']
+	createdSessionInstance = boto3.session.Session(region_name=region)
+	return createdSessionInstance
+
+def autheticateLambdaClient():
+
+	if sessionInstance is None:
+		sessionInstance = createSessionInstance()
+
+
+	return sessionInstance.client('lambda')
+
+def autheticates3Client():
+
+	if sessionInstance is None:
+		sessionInstance = createSessionInstance()
+
+
+	return sessionInstance.client('s3') #add s3 uploader
+	

--- a/src/setup/deployment/raw-code/functions/producer-consumer/util.py
+++ b/src/setup/deployment/raw-code/functions/producer-consumer/util.py
@@ -1,0 +1,39 @@
+import random
+
+ALLOWEDCHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+UNIQUEPAYLOADBYTES = 1024 * 1024
+
+def InitializeGlobalRandomPayload():
+
+	for i in range (0,UNIQUEPAYLOADBYTES):
+		uniquePayload.append(random.randint(0,len(ALLOWEDCHARS)-1))
+
+
+	GlobalRandomPayload = ''.join(str(e) for e in uniquePayload)
+
+	length= len(GlobalRandomPayload)
+	for i in range(0,3):
+		length *= 2
+		GlobalRandomPayload =GeneratePayloadFromGlobalRandom(length)
+
+def GeneratePayloadFromGlobalRandom(payloadLengthBytes):
+	# INCOMPLETE: Not sure where the GlobalRandomPayload variable comes from
+
+	while len(repeatedRandomPayload) < payloadLengthBytes:
+		repeatedRandomPayload = 
+
+def extractJSONTimestampChain(responsePayload):
+	# assuming it's StreamingBody
+	reply = json.load(responsePayload)
+	# or reply = json.loads(payloadResponse.read().decode("utf-8"))
+	return reply["body"]["TimeStampChain"]
+
+def AppendTimestampToChain(timestampChain):
+	return timestampChain.append(time.utcnow())
+
+def StringArrayToArrayOfString(stri):
+	stri1 = stri[1:]
+	stri1 = stri1[:-1]
+	return stri1.split()
+
+


### PR DESCRIPTION
This PR focuses on translating the producer-consumer image from Golang to Python. The reason for the translation is that Golang is not natively supported by Azure Functions (they only have a [work-around where you write a custom handler HTTP server](https://docs.microsoft.com/en-us/azure/azure-functions/create-first-function-vs-code-other?tabs=go%2Clinux) that gets queried by the Azure Function). This wouldn't be a problem in itself if the [serverless.com](https://www.serverless.com) tool supported Golang deployments, but it doesn't either...

Files to be translated include:
- [ ] `producer-consumer/aws/main.go`
- [ ] `producer-consumer/vhive/main.go`
- [x] `producer-consumer/common/aws.go`
- [ ] `producer-consumer/common/grpc.go`
- [ ] `producer-consumer/common/main.go`
- [ ] `producer-consumer/common/object-storage.go`
- [x] `producer-consumer/common/util.go`
- [ ] `producer-consumer/common/util-test.go`