### PR TITLE
Added a script with functions to write latency statistics to DynamoDB

### DIFF
--- a/src/benchmarking/continuous-benchmarking.go
+++ b/src/benchmarking/continuous-benchmarking.go
@@ -1,0 +1,105 @@
+// MIT License
+//
+// Copyright (c) 2022 Dilina Dehigama and EASE Lab
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package benchmarking
+
+import (
+	"encoding/json"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"gonum.org/v1/gonum/stat"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+	"vhive-bench/setup"
+)
+
+type StatisticsRecord struct {
+	ExperimentType    string `json:"experiment_type"`
+	Date              string `json:"date"`
+	SubType           string `json:"subtype"`
+	Min               string `json:"min"`
+	Max               string `json:"max"`
+	Median            string `json:"median"`
+	TailLatency       string `json:"tail_latency"`
+	FirstQuartile     string `json:"first_quartile"`
+	ThirdQuartile     string `json:"third_quartile"`
+	StandardDeviation string `json:"standard_deviation"`
+	PayloadSize       string `json:"payload_size"`
+	BurstSize         string `json:"burst_size"`
+	IATType           string `json:"IAT_type"`
+	Count             int32  `json:"count"`
+	Provider          string `json:"provider"`
+}
+
+func writeStatisticsToDB(sortedLatencies []float64, experiment setup.SubExperiment) {
+	experimentID := experiment.ID
+	log.Infof("[sub-experiment %d] Writing statistics to the database", experimentID)
+	url := "https://51941s0gs7.execute-api.us-west-1.amazonaws.com/results"
+	method := "POST"
+
+	record := StatisticsRecord{
+		ExperimentType:    experiment.Title,
+		Date:              time.Now().Format("2006-01-02"),
+		Min:               fmt.Sprintf("%.2f", stat.Quantile(0, stat.Empirical, sortedLatencies, nil)),
+		Max:               fmt.Sprintf("%.2f", stat.Quantile(1, stat.Empirical, sortedLatencies, nil)),
+		Median:            fmt.Sprintf("%.2f", stat.Quantile(0.50, stat.Empirical, sortedLatencies, nil)),
+		TailLatency:       fmt.Sprintf("%.2f", stat.Quantile(0.99, stat.Empirical, sortedLatencies, nil)),
+		FirstQuartile:     fmt.Sprintf("%.2f", stat.Quantile(0.25, stat.Empirical, sortedLatencies, nil)),
+		ThirdQuartile:     fmt.Sprintf("%.2f", stat.Quantile(0.75, stat.Empirical, sortedLatencies, nil)),
+		StandardDeviation: fmt.Sprintf("%.2f", stat.StdDev(sortedLatencies, nil)),
+		PayloadSize:       strconv.Itoa(experiment.PayloadLengthBytes),
+		BurstSize:         strings.Trim(strings.Join(strings.Fields(fmt.Sprint(experiment.BurstSizes)), ","), "[]"),
+		IATType:           experiment.IATType,
+		Count:             int32(len(sortedLatencies)),
+		Provider:          "aws",
+	}
+
+	jsonRecord, _ := json.Marshal(record)
+
+	payload := strings.NewReader(string(jsonRecord))
+
+	client := &http.Client{}
+	req, err := http.NewRequest(method, url, payload)
+
+	if err != nil {
+		log.Fatalf("[sub-experiment %d] Could not create HTTP request: %s", experimentID, err.Error())
+		return
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := client.Do(req)
+	if err != nil {
+		log.Errorf("[sub-experiment %d] HTTP request was not successful! : %s", experimentID, err.Error())
+		return
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		log.Errorf("[sub-experiment %d] Could not read HTTP response body: %s", experimentID, err.Error())
+		return
+	}
+	log.Infof("[sub-experiment %d] Response received: %s", experimentID, string(body))
+}

--- a/src/benchmarking/post-processing.go
+++ b/src/benchmarking/post-processing.go
@@ -37,7 +37,7 @@ import (
 	"vhive-bench/setup"
 )
 
-func postProcessing(experiment setup.SubExperiment, latenciesFile *os.File, burstDeltas []time.Duration, experimentDirectoryPath string, statisticsFile *os.File) {
+func postProcessing(experiment setup.SubExperiment, latenciesFile *os.File, burstDeltas []time.Duration, experimentDirectoryPath string, statisticsFile *os.File, writeToDatabase bool) {
 	log.Debugf("[sub-experiment %d] Reading written latencies from file %s", experiment.ID, latenciesFile.Name())
 
 	_, err := latenciesFile.Seek(0, io.SeekStart)
@@ -51,10 +51,11 @@ func postProcessing(experiment setup.SubExperiment, latenciesFile *os.File, burs
 	sort.Float64s(sortedLatencies)
 
 	visualization.Generate(experiment, burstDeltas, latenciesDF, sortedLatencies, experimentDirectoryPath)
-	generateStatistics(statisticsFile, experiment.ID, sortedLatencies)
+	generateStatistics(statisticsFile, sortedLatencies, experiment, writeToDatabase)
 }
 
-func generateStatistics(file *os.File, experimentID int, sortedLatencies []float64) {
+func generateStatistics(file *os.File, sortedLatencies []float64, experiment setup.SubExperiment, writeToDatabase bool) {
+	experimentID := experiment.ID
 	log.Debugf("[sub-experiment %d] Generating result statistics...", experimentID)
 
 	statisticsWriter := csv.NewWriter(file)
@@ -79,4 +80,9 @@ func generateStatistics(file *os.File, experimentID int, sortedLatencies []float
 	}
 
 	statisticsWriter.Flush()
+
+	if writeToDatabase == true {
+		writeStatisticsToDB(sortedLatencies, experiment)
+	}
+
 }

--- a/src/benchmarking/trigger.go
+++ b/src/benchmarking/trigger.go
@@ -35,16 +35,16 @@ import (
 	"vhive-bench/setup"
 )
 
-//TriggerSubExperiments will run the sub-experiments specified by the passed configuration object. It creates
-//a directory for each sub-experiment, as well as separate visualizations and latency files.
-func TriggerSubExperiments(config setup.Configuration, outputDirectoryPath string, specificExperiment int) {
+// TriggerSubExperiments will run the sub-experiments specified by the passed configuration object. It creates
+// a directory for each sub-experiment, as well as separate visualizations and latency files.
+func TriggerSubExperiments(config setup.Configuration, outputDirectoryPath string, specificExperiment int, writeToDatabase bool) {
 	var experimentsWaitGroup sync.WaitGroup
 
 	switch specificExperiment {
 	case -1: // run all experiments
 		for experimentIndex := 0; experimentIndex < len(config.SubExperiments); experimentIndex++ {
 			experimentsWaitGroup.Add(1)
-			go triggerSubExperiment(&experimentsWaitGroup, config.Provider, config.SubExperiments[experimentIndex], outputDirectoryPath)
+			go triggerSubExperiment(&experimentsWaitGroup, config.Provider, config.SubExperiments[experimentIndex], outputDirectoryPath, writeToDatabase)
 
 			if config.Sequential {
 				experimentsWaitGroup.Wait()
@@ -56,13 +56,13 @@ func TriggerSubExperiments(config setup.Configuration, outputDirectoryPath strin
 		}
 
 		experimentsWaitGroup.Add(1)
-		go triggerSubExperiment(&experimentsWaitGroup, config.Provider, config.SubExperiments[specificExperiment], outputDirectoryPath)
+		go triggerSubExperiment(&experimentsWaitGroup, config.Provider, config.SubExperiments[specificExperiment], outputDirectoryPath, writeToDatabase)
 	}
 
 	experimentsWaitGroup.Wait()
 }
 
-func triggerSubExperiment(experimentsWaitGroup *sync.WaitGroup, provider string, experiment setup.SubExperiment, outputDirectoryPath string) {
+func triggerSubExperiment(experimentsWaitGroup *sync.WaitGroup, provider string, experiment setup.SubExperiment, outputDirectoryPath string, writeToDatabase bool) {
 	log.Infof("[sub-experiment %d] Starting...", experiment.ID)
 	defer experimentsWaitGroup.Done()
 
@@ -84,7 +84,7 @@ func triggerSubExperiment(experimentsWaitGroup *sync.WaitGroup, provider string,
 
 	runSubExperiment(experiment, burstDeltas, provider, latenciesWriter, dataTransferWriter)
 
-	postProcessing(experiment, latenciesFile, burstDeltas, experimentDirectoryPath, statisticsFile)
+	postProcessing(experiment, latenciesFile, burstDeltas, experimentDirectoryPath, statisticsFile, writeToDatabase)
 
 	log.Infof("[sub-experiment %d] Successfully finished.", experiment.ID)
 }

--- a/src/main.go
+++ b/src/main.go
@@ -42,6 +42,7 @@ var configPathFlag = flag.String("c", "experiments/tests/aws/data-transfer.json"
 var endpointsDirectoryPathFlag = flag.String("g", "endpoints", "Directory containing provider endpoints to be used.")
 var specificExperimentFlag = flag.Int("r", -1, "Only run this particular experiment.")
 var logLevelFlag = flag.String("l", "info", "Select logging level.")
+var writeToDatabaseFlag = flag.Bool("db", false, "This bool flag specifies whether statistics should be written to the database")
 
 func main() {
 	startTime := time.Now()
@@ -76,7 +77,7 @@ func main() {
 
 	setup.ProvisionFunctions(config)
 
-	benchmarking.TriggerSubExperiments(config, outputDirectoryPath, *specificExperimentFlag)
+	benchmarking.TriggerSubExperiments(config, outputDirectoryPath, *specificExperimentFlag, *writeToDatabaseFlag)
 
 	log.Infof("Done in %v, exiting...", time.Since(startTime))
 }


### PR DESCRIPTION
Added functions to write latency statistics to DynamoDB with the following structure.

- 	ExperimentType    string `json:"experiment_type"`
- 	Date              string `json:"date"`
- 	SubType           string `json:"subtype"`
- 	Min               string `json:"min"`
- 	Max               string `json:"max"`
- 	Median            string `json:"median"`
- 	TailLatency       string `json:"tail_latency"`
- 	FirstQuartile     string `json:"first_quartile"`
- 	ThirdQuartile     string `json:"third_quartile"`
- 	StandardDeviation string `json:"standard_deviation"`
- 	PayloadSize       string `json:"payload_size"`
- 	BurstSize         string `json:"burst_size"`
- 	IATType           string `json:"IAT_type"`
- 	Count             int32  `json:"count"`
- 	Provider          string `json:"provider"`

Integrated to main script with a bool flag `db` to decide whether statistics should be written to the database. 