### PR TITLE
Refactor function config key-values to experiment JSON file

### DIFF
--- a/experiments/burstiness/aws/hellopy/container-warm-cold-cdfs.json
+++ b/experiments/burstiness/aws/hellopy/container-warm-cold-cdfs.json
@@ -1,117 +1,94 @@
 {
   "Sequential": false,
+  "Runtime": "python3.9",
   "SubExperiments": [
     {
       "Title": "warm",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
       "Bursts": 6,
-      "BurstSizes": [
-        500
-      ],
+      "BurstSizes": [500],
       "IATSeconds": 25,
       "FunctionMemoryMB": 2048,
       "PackageType": "Image",
-      "DesiredServiceTimes": [
-        "0ms"
-      ]
+      "DesiredServiceTimes": ["0ms"]
     },
     {
       "Title": "cold",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
       "Bursts": 6,
-      "BurstSizes": [
-        500
-      ],
+      "BurstSizes": [500],
       "IATSeconds": 600,
       "FunctionMemoryMB": 2048,
       "PackageType": "Image",
-      "DesiredServiceTimes": [
-        "0ms"
-      ]
+      "DesiredServiceTimes": ["0ms"]
     },
     {
       "Title": "warm",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
       "Bursts": 10,
-      "BurstSizes": [
-        300
-      ],
+      "BurstSizes": [300],
       "IATSeconds": 15,
       "FunctionMemoryMB": 2048,
       "PackageType": "Image",
-      "DesiredServiceTimes": [
-        "0ms"
-      ]
+      "DesiredServiceTimes": ["0ms"]
     },
     {
       "Title": "cold",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
       "Bursts": 10,
-      "BurstSizes": [
-        300
-      ],
+      "BurstSizes": [300],
       "IATSeconds": 600,
       "FunctionMemoryMB": 2048,
       "PackageType": "Image",
-      "DesiredServiceTimes": [
-        "0ms"
-      ]
+      "DesiredServiceTimes": ["0ms"]
     },
     {
       "Title": "warm",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
       "Bursts": 30,
-      "BurstSizes": [
-        100
-      ],
+      "BurstSizes": [100],
       "IATSeconds": 10,
       "FunctionMemoryMB": 2048,
       "PackageType": "Image",
-      "DesiredServiceTimes": [
-        "0ms"
-      ]
+      "DesiredServiceTimes": ["0ms"]
     },
     {
       "Title": "cold",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
       "Bursts": 30,
-      "BurstSizes": [
-        100
-      ],
+      "BurstSizes": [100],
       "IATSeconds": 600,
       "FunctionMemoryMB": 2048,
       "PackageType": "Image",
-      "DesiredServiceTimes": [
-        "0ms"
-      ]
+      "DesiredServiceTimes": ["0ms"]
     },
     {
       "Title": "warm",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
       "Bursts": 3000,
-      "BurstSizes": [
-        1
-      ],
+      "BurstSizes": [1],
       "IATSeconds": 0.5,
       "FunctionMemoryMB": 2048,
       "PackageType": "Image",
-      "DesiredServiceTimes": [
-        "0ms"
-      ]
+      "DesiredServiceTimes": ["0ms"]
     },
     {
       "Title": "cold",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
       "Bursts": 3000,
-      "BurstSizes": [
-        1
-      ],
+      "BurstSizes": [1],
       "IATSeconds": 600,
       "FunctionMemoryMB": 2048,
       "PackageType": "Image",
-      "DesiredServiceTimes": [
-        "0ms"
-      ],
+      "DesiredServiceTimes": ["0ms"],
       "Parallelism": 147
     }
   ]

--- a/experiments/burstiness/aws/hellopy/warm-cold-cdfs.json
+++ b/experiments/burstiness/aws/hellopy/warm-cold-cdfs.json
@@ -4,106 +4,98 @@
     {
       "Title": "warm",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
+      "PackageType": "Zip",
+      "PackagePattern": "hellopy/lambda_function.py",
       "Bursts": 6,
-      "BurstSizes": [
-        500
-      ],
+      "BurstSizes": [500],
       "IATSeconds": 25,
       "FunctionMemoryMB": 2048,
-      "DesiredServiceTimes": [
-        "0ms"
-      ]
+      "DesiredServiceTimes": ["0ms"]
     },
     {
       "Title": "cold",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
+      "PackageType": "Zip",
+      "PackagePattern": "hellopy/lambda_function.py",
       "Bursts": 6,
-      "BurstSizes": [
-        500
-      ],
+      "BurstSizes": [500],
       "IATSeconds": 600,
       "FunctionMemoryMB": 2048,
-      "DesiredServiceTimes": [
-        "0ms"
-      ]
+      "DesiredServiceTimes": ["0ms"]
     },
     {
       "Title": "warm",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
+      "PackageType": "Zip",
+      "PackagePattern": "hellopy/lambda_function.py",
       "Bursts": 10,
-      "BurstSizes": [
-        300
-      ],
+      "BurstSizes": [300],
       "IATSeconds": 15,
       "FunctionMemoryMB": 2048,
-      "DesiredServiceTimes": [
-        "0ms"
-      ]
+      "DesiredServiceTimes": ["0ms"]
     },
     {
       "Title": "cold",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
+      "PackageType": "Zip",
+      "PackagePattern": "hellopy/lambda_function.py",
       "Bursts": 10,
-      "BurstSizes": [
-        300
-      ],
+      "BurstSizes": [300],
       "IATSeconds": 600,
       "FunctionMemoryMB": 2048,
-      "DesiredServiceTimes": [
-        "0ms"
-      ]
+      "DesiredServiceTimes": ["0ms"]
     },
     {
       "Title": "warm",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
+      "PackageType": "Zip",
+      "PackagePattern": "hellopy/lambda_function.py",
       "Bursts": 30,
-      "BurstSizes": [
-        100
-      ],
+      "BurstSizes": [100],
       "IATSeconds": 10,
       "FunctionMemoryMB": 2048,
-      "DesiredServiceTimes": [
-        "0ms"
-      ]
+      "DesiredServiceTimes": ["0ms"]
     },
     {
       "Title": "cold",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
+      "PackageType": "Zip",
+      "PackagePattern": "hellopy/lambda_function.py",
       "Bursts": 30,
-      "BurstSizes": [
-        100
-      ],
+      "BurstSizes": [100],
       "IATSeconds": 600,
       "FunctionMemoryMB": 2048,
-      "DesiredServiceTimes": [
-        "0ms"
-      ]
+      "DesiredServiceTimes": ["0ms"]
     },
     {
       "Title": "warm",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
+      "PackageType": "Zip",
+      "PackagePattern": "hellopy/lambda_function.py",
       "Bursts": 3000,
-      "BurstSizes": [
-        1
-      ],
+      "BurstSizes": [1],
       "IATSeconds": 0.5,
       "FunctionMemoryMB": 2048,
-      "DesiredServiceTimes": [
-        "0ms"
-      ]
+      "DesiredServiceTimes": ["0ms"]
     },
     {
       "Title": "cold",
       "Function": "hellopy",
+      "Handler": "hellopy/lambda_function.lambda_handler",
+      "PackageType": "Zip",
+      "PackagePattern": "hellopy/lambda_function.py",
       "Bursts": 3000,
-      "BurstSizes": [
-        1
-      ],
+      "BurstSizes": [1],
       "IATSeconds": 600,
       "FunctionMemoryMB": 2048,
-      "DesiredServiceTimes": [
-        "0ms"
-      ],
+      "DesiredServiceTimes": ["0ms"],
       "Parallelism": 147
     }
   ]

--- a/experiments/coldboot-predictability/aws/coldstart-cdfs.json
+++ b/experiments/coldboot-predictability/aws/coldstart-cdfs.json
@@ -33,6 +33,9 @@
     {
       "Title": "hellopy",
       "Function": "hellopy",
+	  "Handler": "hellopy/lambda_function.lambda_handler",
+	  "PackageType": "Zip",
+	  "PackagePattern": "hellopy/lambda_function.py",
       "Bursts": 500,
       "BurstSizes": [
         1

--- a/experiments/coldboot-predictability/vhive/coldstart-cdfs.json
+++ b/experiments/coldboot-predictability/vhive/coldstart-cdfs.json
@@ -31,6 +31,9 @@
     {
       "Title": "hellopy",
       "Function": "hellopy",
+	  "Handler": "hellopy/lambda_function.lambda_handler",
+	  "PackageType": "Zip",
+	  "PackagePattern": "hellopy/lambda_function.py",
       "Bursts": 500,
       "BurstSizes": [
         1

--- a/experiments/tests/aws/hellopy.json
+++ b/experiments/tests/aws/hellopy.json
@@ -1,10 +1,14 @@
 {
   "Sequential": false,
   "Provider": "aws",
+  "Runtime": "python3.9",
   "SubExperiments": [
     {
       "Title": "parallelism1",
       "Function": "hellopy",
+	  "Handler": "hellopy/lambda_function.lambda_handler",
+	  "PackageType": "Zip",
+	  "PackagePattern": "hellopy/lambda_function.py",
       "Bursts": 2,
       "BurstSizes": [
         2
@@ -17,6 +21,9 @@
     {
       "Title": "parallelism2",
       "Function": "hellopy",
+	  "Handler": "hellopy/lambda_function.lambda_handler",
+	  "PackageType": "Zip",
+	  "PackagePattern": "hellopy/lambda_function.py",
       "Bursts": 3,
       "BurstSizes": [
         4

--- a/src/setup/extract-configuration.go
+++ b/src/setup/extract-configuration.go
@@ -74,7 +74,10 @@ const (
 	defaultIATType                 = "stochastic"
 	defaultProvider                = "aws"
 	defaultFunction                = "producer-consumer"
+	defaultHandler                 = "producer-consumer"
+	defaultRuntime                 = "go1.x"
 	defaultPackageType             = "Zip"
+	defaultPackagePattern          = "**"
 	defaultParallelism             = 1
 	defaultDataTransferChainLength = 1
 	defaultFunctionMemoryMB        = 128

--- a/src/setup/extract-configuration.go
+++ b/src/setup/extract-configuration.go
@@ -96,6 +96,9 @@ func ExtractConfiguration(configFilePath string) Configuration {
 	if parsedConfig.Provider == "" {
 		parsedConfig.Provider = defaultProvider
 	}
+	if parsedConfig.Runtime == "" {
+		parsedConfig.Runtime = defaultRuntime
+	}
 
 	for index := range parsedConfig.SubExperiments {
 		if parsedConfig.SubExperiments[index].Function == "" {

--- a/src/setup/extract-configuration.go
+++ b/src/setup/extract-configuration.go
@@ -33,6 +33,7 @@ import (
 type Configuration struct {
 	Sequential     bool            `json:"Sequential"`
 	Provider       string          `json:"Provider"`
+	Runtime        string          `json:"Runtime"`
 	SubExperiments []SubExperiment `json:"SubExperiments"`
 }
 

--- a/src/setup/extract-configuration.go
+++ b/src/setup/extract-configuration.go
@@ -29,20 +29,20 @@ import (
 	"stellar/util"
 )
 
-//Configuration is the schema for all experiment configurations.
+// Configuration is the schema for all experiment configurations.
 type Configuration struct {
 	Sequential     bool            `json:"Sequential"`
 	Provider       string          `json:"Provider"`
 	SubExperiments []SubExperiment `json:"SubExperiments"`
 }
 
-//EndpointInfo contains an ID identifying the function together with the IDs of other functions further in the data transfer chain
+// EndpointInfo contains an ID identifying the function together with the IDs of other functions further in the data transfer chain
 type EndpointInfo struct {
 	ID                   string
 	DataTransferChainIDs []string
 }
 
-//SubExperiment contains all the information needed for a sub-experiment to run.
+// SubExperiment contains all the information needed for a sub-experiment to run.
 type SubExperiment struct {
 	ID                      int
 	Title                   string   `json:"Title"`
@@ -76,7 +76,7 @@ const (
 	defaultFunctionMemoryMB        = 128
 )
 
-//ExtractConfiguration will read and parse the JSON configuration file, assign any default values and return the config object
+// ExtractConfiguration will read and parse the JSON configuration file, assign any default values and return the config object
 func ExtractConfiguration(configFilePath string) Configuration {
 	configFile := util.ReadFile(configFilePath)
 	configByteValue, _ := io.ReadAll(configFile)

--- a/src/setup/extract-configuration.go
+++ b/src/setup/extract-configuration.go
@@ -61,6 +61,9 @@ type SubExperiment struct {
 	FunctionImageSizeMB     float64  `json:"FunctionImageSizeMB"`
 	DataTransferChainLength int      `json:"DataTransferChainLength"`
 	StorageTransfer         bool     `json:"StorageTransfer"`
+	Handler                 string   `json:"Handler"`
+	Runtime                 string   `json:"Runtime"`
+	PackagePattern          string   `json:"PackagePattern"`
 	// All of the below are computed after reading the configuration
 	BusySpinIncrements []int64 `json:"BusySpinIncrements"`
 	Endpoints          []EndpointInfo

--- a/src/setup/extract-configuration.go
+++ b/src/setup/extract-configuration.go
@@ -104,11 +104,20 @@ func ExtractConfiguration(configFilePath string) Configuration {
 		if parsedConfig.SubExperiments[index].Function == "" {
 			parsedConfig.SubExperiments[index].Function = defaultFunction
 		}
+		if parsedConfig.SubExperiments[index].Handler == "" {
+			parsedConfig.SubExperiments[index].Handler = defaultHandler
+		}
+		if parsedConfig.SubExperiments[index].Runtime == "" {
+			parsedConfig.SubExperiments[index].Runtime = defaultRuntime
+		}
 		if parsedConfig.SubExperiments[index].Visualization == "" {
 			parsedConfig.SubExperiments[index].Visualization = defaultVisualization
 		}
 		if parsedConfig.SubExperiments[index].PackageType == "" {
 			parsedConfig.SubExperiments[index].PackageType = defaultPackageType
+		}
+		if parsedConfig.SubExperiments[index].PackagePattern == "" {
+			parsedConfig.SubExperiments[index].PackagePattern = defaultPackagePattern
 		}
 		if parsedConfig.SubExperiments[index].IATType == "" {
 			parsedConfig.SubExperiments[index].IATType = defaultIATType


### PR DESCRIPTION
Fixes issue #263.

## Changes
- Update Configuration struct to include `Runtime` field
- Update SubExperiment struct to include `Handler` and `PackagePattern` fields
- Add default values for newly added fields (Runtime, Handler, PackagePattern)
- Update hellopy experiment JSON files to include new fields
- ~~Replace hardcoded values in `src/setup/serverless-config.go` with newly added fields~~ _(Awaiting Serverless config PR before doing this)_

These fields must now be specified in the experiment JSON file. More fields can be added to the Configuration/SubExperiment struct as needed in the future.

**Note:** Github Actions seem to be failing because this branch is from a fork and does not have access to credentials.