### PR TITLE
Add function-level packaging and artifact field to serverless.yml files

### DIFF
--- a/src/setup/building/builder.go
+++ b/src/setup/building/builder.go
@@ -9,17 +9,17 @@ import (
 
 // Builder struct keeps track of the functions built by stellar
 type Builder struct {
-	functionsBuilt []string
+	functionsBuilt map[string]bool
 }
 
 func (b *Builder) BuildFunction(provider string, functionName string, runtime string) {
-	// TODO: Implement function
-
 	// First we check whether the function has not been built already
-	// TODO: Check if function path is in functionsBuilt if yes, skip the build. If no, continue the building process and add the functionPath to the list.
+	if b.functionsBuilt[functionName] {
+		log.Warnf("Function %s already built. Skipping.", functionName)
+		return
+	}
 
 	functionPath := fmt.Sprintf("setup/deployment/raw-code/serverless/%s/%s", provider, functionName)
-	b.functionsBuilt = append(b.functionsBuilt, functionPath)
 	switch runtime {
 	case "java":
 		buildJava(functionPath)
@@ -28,7 +28,9 @@ func (b *Builder) BuildFunction(provider string, functionName string, runtime st
 	default:
 		// building not supported
 		log.Warnf("Building runtime %s is not necessary, or not supported. Continuing without building.", runtime)
+		return
 	}
+	b.functionsBuilt[functionName] = true
 }
 
 // buildJava builds the java zip artifact for serverless deployment using Gradle

--- a/src/setup/building/builder.go
+++ b/src/setup/building/builder.go
@@ -16,6 +16,10 @@ type Builder struct {
 
 func (b *Builder) BuildFunction(provider string, functionName string, runtime string) string {
 	// First we check whether the function has not been built already
+	if b.functionsBuilt == nil {
+		b.functionsBuilt = make(map[string]bool)
+	}
+
 	if b.functionsBuilt[functionName] {
 		log.Warnf("Function %s already built. Skipping.", functionName)
 		return fmt.Sprintf("%s/%s/%s.zip", artifactDir, functionName, functionName)

--- a/src/setup/building/builder.go
+++ b/src/setup/building/builder.go
@@ -7,16 +7,18 @@ import (
 	"stellar/util"
 )
 
+const artifactDir = "setup/artifacts"
+
 // Builder struct keeps track of the functions built by stellar
 type Builder struct {
 	functionsBuilt map[string]bool
 }
 
-func (b *Builder) BuildFunction(provider string, functionName string, runtime string) {
+func (b *Builder) BuildFunction(provider string, functionName string, runtime string) string {
 	// First we check whether the function has not been built already
 	if b.functionsBuilt[functionName] {
 		log.Warnf("Function %s already built. Skipping.", functionName)
-		return
+		return fmt.Sprintf("%s/%s/%s.zip", artifactDir, functionName, functionName)
 	}
 
 	functionPath := fmt.Sprintf("setup/deployment/raw-code/serverless/%s/%s", provider, functionName)
@@ -28,9 +30,10 @@ func (b *Builder) BuildFunction(provider string, functionName string, runtime st
 	default:
 		// building not supported
 		log.Warnf("Building runtime %s is not necessary, or not supported. Continuing without building.", runtime)
-		return
+		return ""
 	}
 	b.functionsBuilt[functionName] = true
+	return fmt.Sprintf("%s/%s/%s.zip", artifactDir, functionName, functionName)
 }
 
 // buildJava builds the java zip artifact for serverless deployment using Gradle

--- a/src/setup/building/test/building_test.go
+++ b/src/setup/building/test/building_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestBuildFunctionJava(t *testing.T) {
 	b := &building.Builder{}
-	b.BuildFunction("mockProvider", "mockFunctionName", "java")
+	b.BuildFunction("aws", "test/function/path", "java11")
 }
 
 func TestBuildFunctionGolang(t *testing.T) {

--- a/src/setup/run.go
+++ b/src/setup/run.go
@@ -93,14 +93,12 @@ func ProvisionFunctionsServerless(config Configuration) {
 	slsConfig.CreateHeaderConfig(&config)
 
 	for index, subExperiment := range config.SubExperiments {
-
-		slsConfig.AddFunctionConfig(&subExperiment, index)
-
 		//TODO: generate the code
 		code_generation.GenerateCode(subExperiment.Function, config.Provider)
 
 		// TODO: build the functions (Java and Golang)
-		builder.BuildFunction(config.Provider, subExperiment.Function, subExperiment.Runtime)
+		artifactPath := builder.BuildFunction("", "", "")
+		slsConfig.AddFunctionConfig(&subExperiment, index, artifactPath)
 
 		// TODO: Create filler files here and do the zipping if necessary.
 		// Use deployment.generateFillerFile() function

--- a/src/setup/run.go
+++ b/src/setup/run.go
@@ -92,6 +92,13 @@ func ProvisionFunctionsServerless(config Configuration) {
 
 	slsConfig.CreateHeaderConfig(&config)
 
+	if _, err := os.Stat("setup/artifacts"); os.IsNotExist(err) {
+		log.Info("Creating artifacts directory...")
+		if err := os.MkdirAll("setup/artifacts", os.ModePerm); err != nil {
+			log.Fatalf("Error creating artifacts directory: %s", err.Error())
+		}
+	}
+
 	for index, subExperiment := range config.SubExperiments {
 		//TODO: generate the code
 		code_generation.GenerateCode(subExperiment.Function, config.Provider)

--- a/src/setup/run.go
+++ b/src/setup/run.go
@@ -104,7 +104,7 @@ func ProvisionFunctionsServerless(config Configuration) {
 		code_generation.GenerateCode(subExperiment.Function, config.Provider)
 
 		// TODO: build the functions (Java and Golang)
-		artifactPath := builder.BuildFunction("", "", "")
+		artifactPath := builder.BuildFunction(config.Provider, subExperiment.Function, subExperiment.Runtime)
 		slsConfig.AddFunctionConfig(&subExperiment, index, artifactPath)
 
 		// TODO: Create filler files here and do the zipping if necessary.

--- a/src/setup/serverless-config.go
+++ b/src/setup/serverless-config.go
@@ -39,7 +39,7 @@ type Function struct {
 
 type FunctionPackage struct {
 	Patterns []string `yaml:"patterns"`
-	Artifact string   `yaml:"artifact"`
+	Artifact string   `yaml:"artifact,omitempty"`
 }
 
 type Event struct {

--- a/src/setup/serverless-config.go
+++ b/src/setup/serverless-config.go
@@ -26,14 +26,20 @@ type Provider struct {
 }
 
 type Package struct {
-	Patterns []string `yaml:"patterns"`
+	Individually bool `yaml:"individually"`
 }
 
 type Function struct {
-	Handler string  `yaml:"handler"`
-	Runtime string  `yaml:"runtime"`
-	Name    string  `yaml:"name"`
-	Events  []Event `yaml:"events"`
+	Handler string          `yaml:"handler"`
+	Runtime string          `yaml:"runtime"`
+	Name    string          `yaml:"name"`
+	Events  []Event         `yaml:"events"`
+	Package FunctionPackage `yaml:"package"`
+}
+
+type FunctionPackage struct {
+	Patterns []string `yaml:"patterns"`
+	Artifact string   `yaml:"artifact"`
 }
 
 type Event struct {

--- a/src/setup/serverless-config.go
+++ b/src/setup/serverless-config.go
@@ -83,7 +83,7 @@ func (f *Function) AddPackagePattern(pattern string) {
 }
 
 // AddFunctionConfig Adds a function to the service. If parallelism = n, then it defines n functions. Also deploys all producer-consumer subfunctions.
-func (s *Serverless) AddFunctionConfig(subex *SubExperiment, index int) {
+func (s *Serverless) AddFunctionConfig(subex *SubExperiment, index int, artifactPath string) {
 	log.Warnf("Adding function config of Subexperiment %s, index %d", subex.Function, index)
 	if s.Functions == nil {
 		s.Functions = make(map[string]*Function)
@@ -97,6 +97,9 @@ func (s *Serverless) AddFunctionConfig(subex *SubExperiment, index int) {
 
 		f := &Function{Handler: handler, Runtime: runtime, Name: name, Events: events}
 		f.AddPackagePattern(subex.PackagePattern)
+		if artifactPath != "" {
+			f.Package.Artifact = artifactPath
+		}
 		s.Functions[name] = f
 
 		// TODO: producer-consumer sub-function definition

--- a/src/setup/serverless-config.go
+++ b/src/setup/serverless-config.go
@@ -72,13 +72,13 @@ func (s *Serverless) CreateHeaderConfig(config *Configuration) {
 		Runtime: config.Runtime,
 		Region:  region,
 	}
-	s.AddPackagePattern("!**")
+	s.Package.Individually = true
 }
 
 // AddPackagePattern adds a string pattern to Package.Pattern as long as such a pattern does not already exist in Package.Pattern
-func (s *Serverless) AddPackagePattern(pattern string) {
-	if !util.StringContains(s.Package.Patterns, pattern) {
-		s.Package.Patterns = append(s.Package.Patterns, pattern)
+func (f *Function) AddPackagePattern(pattern string) {
+	if !util.StringContains(f.Package.Patterns, pattern) {
+		f.Package.Patterns = append(f.Package.Patterns, pattern)
 	}
 }
 
@@ -96,7 +96,7 @@ func (s *Serverless) AddFunctionConfig(subex *SubExperiment, index int) {
 		events := []Event{{HttpApi{Path: "/" + name, Method: "GET"}}}
 
 		f := &Function{Handler: handler, Runtime: runtime, Name: name, Events: events}
-		s.AddPackagePattern(subex.PackagePattern)
+		f.AddPackagePattern(subex.PackagePattern)
 		s.Functions[name] = f
 
 		// TODO: producer-consumer sub-function definition

--- a/src/setup/test/serverless-config_test.go
+++ b/src/setup/test/serverless-config_test.go
@@ -19,7 +19,7 @@ func TestCreateHeaderConfig(t *testing.T) {
 			Runtime: "go1.x",
 			Region:  "us-west-1",
 		},
-		Package: setup.Package{Patterns: []string{"!**"}},
+		Package: setup.Package{Individually: true},
 	}
 
 	// Define the Configuration struct for testing
@@ -36,7 +36,7 @@ func TestCreateHeaderConfig(t *testing.T) {
 
 func TestAddFunctionConfig(t *testing.T) {
 	expected := &setup.Serverless{
-		Package: setup.Package{Patterns: []string{"pattern1"}},
+		Package: setup.Package{Individually: true},
 		Functions: map[string]*setup.Function{
 			"test1_2_0": {
 				Name:    "test1_2_0",
@@ -52,10 +52,10 @@ func TestAddFunctionConfig(t *testing.T) {
 					{HttpApi: setup.HttpApi{Path: "/test1_2_1", Method: "GET"}}}},
 		}}
 
-	actual := &setup.Serverless{}
+	actual := &setup.Serverless{Package: setup.Package{Individually: true}}
 
 	subEx := &setup.SubExperiment{Title: "test1", Parallelism: 2, Runtime: "Python3.8", Handler: "hellopy/lambda_function.lambda_handler", PackagePattern: "pattern1"}
-	actual.AddFunctionConfig(subEx, 2)
+	actual.AddFunctionConfig(subEx, 2, "")
 
 	require.Equal(t, expected, actual)
 }
@@ -73,7 +73,7 @@ func TestCreateServerlessConfigFile(t *testing.T) {
 			Region:  "us-east-1",
 		},
 		Package: setup.Package{
-			Patterns: []string{"pattern1", "pattern2"},
+			Individually: true,
 		},
 		Functions: map[string]*setup.Function{
 			"testFunction1": {
@@ -122,27 +122,27 @@ func TestDeployService(t *testing.T) {
 func TestAddPackagePattern(t *testing.T) {
 	assert := require.New(t)
 
-	// Create a sample Serverless instance
-	serverless := &setup.Serverless{
-		Package: setup.Package{
+	// Create a sample Serverless function instance
+	function := &setup.Function{
+		Package: setup.FunctionPackage{
 			Patterns: []string{"pattern1", "pattern2"},
 		},
 	}
 
 	// Call the AddPackagePattern function with a new pattern
 	newPattern := "pattern3"
-	serverless.AddPackagePattern(newPattern)
+	function.AddPackagePattern(newPattern)
 
 	// Verify that the new pattern has been added
-	assert.Contains(serverless.Package.Patterns, newPattern, "New pattern not added")
+	assert.Contains(function.Package.Patterns, newPattern, "New pattern not added")
 
 	// Call the AddPackagePattern function with an existing pattern
 	existingPattern := "pattern1"
-	serverless.AddPackagePattern(existingPattern)
+	function.AddPackagePattern(existingPattern)
 
 	// Verify that the existing pattern is not duplicated
 	count := 0
-	for _, p := range serverless.Package.Patterns {
+	for _, p := range function.Package.Patterns {
 		if p == existingPattern {
 			count++
 		}

--- a/src/setup/test/serverless-config_test.go
+++ b/src/setup/test/serverless-config_test.go
@@ -42,12 +42,20 @@ func TestAddFunctionConfig(t *testing.T) {
 				Name:    "test1_2_0",
 				Handler: "hellopy/lambda_function.lambda_handler",
 				Runtime: "Python3.8",
+				Package: setup.FunctionPackage{
+					Patterns: []string{"pattern1"},
+					Artifact: "",
+				},
 				Events: []setup.Event{
 					{HttpApi: setup.HttpApi{Path: "/test1_2_0", Method: "GET"}}}},
 			"test1_2_1": {
 				Name:    "test1_2_1",
 				Handler: "hellopy/lambda_function.lambda_handler",
 				Runtime: "Python3.8",
+				Package: setup.FunctionPackage{
+					Patterns: []string{"pattern1"},
+					Artifact: "",
+				},
 				Events: []setup.Event{
 					{HttpApi: setup.HttpApi{Path: "/test1_2_1", Method: "GET"}}}},
 		}}
@@ -79,7 +87,10 @@ func TestCreateServerlessConfigFile(t *testing.T) {
 			"testFunction1": {
 				Handler: "handler1",
 				Runtime: "go1.16",
-				Name:    "testFunction1",
+				Package: setup.FunctionPackage{
+					Patterns: []string{"pattern1"},
+				},
+				Name: "testFunction1",
 				Events: []setup.Event{
 					{
 						HttpApi: setup.HttpApi{

--- a/src/setup/test/test.yml
+++ b/src/setup/test/test.yml
@@ -5,9 +5,7 @@ provider:
     runtime: go1.x
     region: us-east-1
 package:
-    patterns:
-        - pattern1
-        - pattern2
+    individually: true
 functions:
     testFunction1:
         handler: handler1
@@ -17,3 +15,6 @@ functions:
             - httpApi:
                 path: /test1
                 method: GET
+        package:
+            patterns:
+                - pattern1


### PR DESCRIPTION
This PR resolves #271.

The top-level packaging in `serverless.yml` will now always be of the form:
```yml
package:
  individually: true
```
Each function is packaged individually by reading in `PackagePattern` from the experiment JSON file, and built artifact paths are also specified in this level:

```yml
functions:
  hellojava:
    package:
      patterns:
        - ...
      artifact: setup/artifacts/hellojava/hellojava.zip
```

All artifacts are assumed to be stored in the folder `src/setup/artifacts/<function_name>/<artifact>` for now, this can be changed if necessary.

## Changes
- Creates a new dir, `src/setup/artifacts/` during the run to store binaries/packages from the builder
- Function signature of `BuildFunction` changed to return the path of the built artifact; function parameters also changed so that the function path is created inside `BuildFunction` instead of passed in
- Change functionsBuilt from []string to map[string]bool, add skipping of builds if function has already been built
- `Package` struct modified in `serverles-config.go`: It now only contains the top level field `individually` which will be set to true at all times via `CreateHeaderConfig`
- Add `FunctionPackage` struct with fields for function-level packaging
- Update `AddPackagePattern` function to work on function-level instead of top-level
- Update `AddFunctionConfig` with artifact path parameter and adding of artifact path 
- Update function calls to `BuildFunction` and `AddFunctionConfig` with new function signatures
- Tests have been updated to follow the new structs and function signatures