### PR TITLE
generate filler files and zip packages

### DIFF
--- a/.github/workflows/feature-serverless-framework-deployment.yml
+++ b/.github/workflows/feature-serverless-framework-deployment.yml
@@ -165,10 +165,10 @@ jobs:
         working-directory: ${{env.working-directory}}
         run: go test -short -v ./setup/code-generation/test/...
 
-      - name: Unit tests deployment
-        working-directory: ${{env.working-directory}}
-        run: go test -short -v ./setup/deployment/...
-
       - name: Unit tests packaging
         working-directory: ${{env.working-directory}}
         run: go test -short -v ./setup/deployment/packaging/test/...
+
+      - name: Unit tests connection
+        working-directory: ${{env.working-directory}}
+        run: go test -short -v ./setup/deployment/connection/...

--- a/.github/workflows/feature-serverless-framework-deployment.yml
+++ b/.github/workflows/feature-serverless-framework-deployment.yml
@@ -168,3 +168,7 @@ jobs:
       - name: Unit tests deployment
         working-directory: ${{env.working-directory}}
         run: go test -short -v ./setup/deployment/...
+
+      - name: Unit tests packaging
+        working-directory: ${{env.working-directory}}
+        run: go test -short -v ./setup/deployment/packaging/test/...

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ pkg
 
 serverless.yml
 .serverless
+src/setup/deployment/raw-code/serverless/aws/artifacts
+.DS_Store

--- a/experiments/tests/aws/hellogo.json
+++ b/experiments/tests/aws/hellogo.json
@@ -6,9 +6,9 @@
     {
       "Title": "parallelism1",
       "Function": "hellogo",
-      "Handler": "hellogo/main",
+      "Handler": "main",
       "PackageType": "Zip",
-      "PackagePattern": "hellogo/main.go",
+      "PackagePattern": "main.go",
       "Bursts": 2,
       "BurstSizes": [
         2
@@ -21,9 +21,9 @@
     {
       "Title": "parallelism2",
       "Function": "hellogo",
-      "Handler": "hellogo/main",
+      "Handler": "main",
       "PackageType": "Zip",
-      "PackagePattern": "hellogo/main.go",
+      "PackagePattern": "main.go",
       "Bursts": 3,
       "BurstSizes": [
         4

--- a/experiments/tests/aws/hellopy.json
+++ b/experiments/tests/aws/hellopy.json
@@ -6,9 +6,9 @@
     {
       "Title": "parallelism1",
       "Function": "hellopy",
-	  "Handler": "hellopy/lambda_function.lambda_handler",
+	  "Handler": "lambda_function.lambda_handler",
 	  "PackageType": "Zip",
-	  "PackagePattern": "hellopy/lambda_function.py",
+	  "PackagePattern": "lambda_function.py",
       "Bursts": 2,
       "BurstSizes": [
         2
@@ -21,9 +21,9 @@
     {
       "Title": "parallelism2",
       "Function": "hellopy",
-	  "Handler": "hellopy/lambda_function.lambda_handler",
+	  "Handler": "lambda_function.lambda_handler",
 	  "PackageType": "Zip",
-	  "PackagePattern": "hellopy/lambda_function.py",
+	  "PackagePattern": "lambda_function.py",
       "Bursts": 3,
       "BurstSizes": [
         4

--- a/src/setup/building/test/building_test.go
+++ b/src/setup/building/test/building_test.go
@@ -15,7 +15,7 @@ type BuildingTestSuite struct {
 }
 
 func (s *BuildingTestSuite) SetupSuite() {
-	if err := os.Chdir("../../.."); err != nil { // so that BuildFunction generates binaries in the correct path relative to the /src directory")
+	if err := os.Chdir("../../.."); err != nil { // so that BuildFunction generates binaries in the correct path relative to the /src directory
 		log.Fatal("Failed to change to /src directory ")
 	}
 }
@@ -29,7 +29,7 @@ func (s *BuildingTestSuite) TestBuildFunctionJava() {
 func (s *BuildingTestSuite) TestBuildFunctionGolang() {
 	b := &building.Builder{}
 	b.BuildFunction("aws", "hellogo", "go1.x")
-	assert.FileExists(s.T(), "setup/deployment/raw-code/serverless/aws/hellogo/main")
+	assert.FileExists(s.T(), "setup/deployment/raw-code/serverless/aws/artifacts/hellogo/main")
 }
 
 func (s *BuildingTestSuite) TestBuildFunctionUnsupported() {

--- a/src/setup/deployment/packaging/test/zip_test.go
+++ b/src/setup/deployment/packaging/test/zip_test.go
@@ -1,0 +1,39 @@
+package packaging
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"os"
+	"stellar/setup/building"
+	"stellar/setup/deployment/packaging"
+	"testing"
+)
+
+type ZipTestSuite struct {
+	suite.Suite
+}
+
+func (s *ZipTestSuite) SetupSuite() {
+	if err := os.Chdir("../../../.."); err != nil {
+		log.Fatal("Failed to change to /src directory ")
+	}
+}
+
+func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsPython() {
+	b := &building.Builder{}
+	b.BuildFunction("aws", "hellopy", "python3.9")
+	packaging.GenerateServerlessZIPArtifacts(1, "aws", "python3.9", "hellopy", 50)
+	assert.FileExists(s.T(), "setup/deployment/raw-code/serverless/aws/artifacts/hellopy/hellopy.zip")
+}
+
+func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsGolang() {
+	b := &building.Builder{}
+	b.BuildFunction("aws", "hellogo", "go1.x")
+	packaging.GenerateServerlessZIPArtifacts(2, "aws", "go1.x", "hellogo", 50)
+	assert.FileExists(s.T(), "setup/deployment/raw-code/serverless/aws/artifacts/hellogo/hellogo.zip")
+}
+
+func TestZipTestSuite(t *testing.T) {
+	suite.Run(t, new(ZipTestSuite))
+}

--- a/src/setup/deployment/packaging/test/zip_test.go
+++ b/src/setup/deployment/packaging/test/zip_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"stellar/setup/building"
 	"stellar/setup/deployment/packaging"
+	"stellar/util"
 	"testing"
 )
 
@@ -24,14 +25,22 @@ func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsPython() {
 	b := &building.Builder{}
 	b.BuildFunction("aws", "hellopy", "python3.9")
 	packaging.GenerateServerlessZIPArtifacts(1, "aws", "python3.9", "hellopy", 50)
-	assert.FileExists(s.T(), "setup/deployment/raw-code/serverless/aws/artifacts/hellopy/hellopy.zip")
+	fileInfo, err := os.Stat("setup/deployment/raw-code/serverless/aws/artifacts/hellopy/hellopy.zip")
+	if err != nil {
+		assert.Fail(s.T(), "Could not obtain file info of ZIP artifact")
+	}
+	assert.InDelta(s.T(), 50, util.BytesToMB(fileInfo.Size()), 0.1)
 }
 
 func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsGolang() {
 	b := &building.Builder{}
 	b.BuildFunction("aws", "hellogo", "go1.x")
 	packaging.GenerateServerlessZIPArtifacts(2, "aws", "go1.x", "hellogo", 50)
-	assert.FileExists(s.T(), "setup/deployment/raw-code/serverless/aws/artifacts/hellogo/hellogo.zip")
+	fileInfo, err := os.Stat("setup/deployment/raw-code/serverless/aws/artifacts/hellogo/hellogo.zip")
+	if err != nil {
+		assert.Fail(s.T(), "Could not obtain file info of ZIP artifact")
+	}
+	assert.InDelta(s.T(), 50, util.BytesToMB(fileInfo.Size()), 0.1)
 }
 
 func TestZipTestSuite(t *testing.T) {

--- a/src/setup/deployment/packaging/test/zip_test.go
+++ b/src/setup/deployment/packaging/test/zip_test.go
@@ -21,6 +21,24 @@ func (s *ZipTestSuite) SetupSuite() {
 	}
 }
 
+func (s *ZipTestSuite) TestGenerateFillerFile() {
+	expectedFillerFileSizeMB := 30.0
+
+	packaging.GenerateFillerFile(1, "filler.file", util.MBToBytes(expectedFillerFileSizeMB))
+
+	fileInfo, err := os.Stat("filler.file")
+	if err != nil {
+		assert.Fail(s.T(), "Could not obtain file info of ZIP artifact")
+	}
+	actualFillerFileSize := util.BytesToMB(fileInfo.Size())
+	assert.InDelta(s.T(), expectedFillerFileSizeMB, actualFillerFileSize, 0.1)
+
+	err = os.Remove("filler.file")
+	if err != nil {
+		log.Warn("Failed to clean up temporary filler files created by unit tests")
+	}
+}
+
 func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsPython() {
 	b := &building.Builder{}
 	b.BuildFunction("aws", "hellopy", "python3.9")

--- a/src/setup/run.go
+++ b/src/setup/run.go
@@ -32,6 +32,7 @@ import (
 	code_generation "stellar/setup/code-generation"
 	"stellar/setup/deployment/connection"
 	"stellar/setup/deployment/connection/amazon"
+	"stellar/setup/deployment/packaging"
 	"time"
 )
 
@@ -100,9 +101,8 @@ func ProvisionFunctionsServerless(config Configuration, serverlessDirPath string
 		artifactPathRelativeToServerlessConfigFile := builder.BuildFunction(config.Provider, subExperiment.Function, subExperiment.Runtime)
 		slsConfig.AddFunctionConfig(&subExperiment, index, artifactPathRelativeToServerlessConfigFile)
 
-		// TODO: Create filler files here and do the zipping if necessary.
-		// Use deployment.generateFillerFile() function
-		// Use the packaging.GenerateZIP() function
+		// generate filler files and zip used as Serverless artifacts
+		packaging.GenerateServerlessZIPArtifacts(subExperiment.ID, config.Provider, subExperiment.Runtime, subExperiment.Function, subExperiment.FunctionImageSizeMB)
 	}
 
 	slsConfig.CreateServerlessConfigFile(fmt.Sprintf("%sserverless.yml", serverlessDirPath))


### PR DESCRIPTION
Partially resolves #255, as filler files for Java builds have not been completed. That needs to be done in a slightly different way as they need to be added to an existing ZIP archive that has already been built by Gradle. I will test and implement it soon in a separate PR.