### PR TITLE
Build Java artifacts

### DIFF
--- a/experiments/tests/aws/hellojava.json
+++ b/experiments/tests/aws/hellojava.json
@@ -1,0 +1,36 @@
+{
+  "Sequential": false,
+  "Provider": "aws",
+  "Runtime": "java11",
+  "SubExperiments": [
+    {
+      "Title": "parallelism1",
+      "Function": "hellojava",
+	  "Handler": "org.hellojava.Handler",
+	  "PackageType": "Zip",
+      "Bursts": 2,
+      "BurstSizes": [
+        2
+      ],
+      "DesiredServiceTimes": [
+        "0ms"
+      ],
+      "FunctionImageSizeMB": 24
+    },
+    {
+      "Title": "parallelism2",
+      "Function": "hellojava",
+	  "Handler": "org.hellojava.Handler",
+	  "PackageType": "Zip",
+      "Bursts": 3,
+      "BurstSizes": [
+        4
+      ],
+      "DesiredServiceTimes": [
+        "0ms"
+      ],
+      "FunctionImageSizeMB": 48,
+      "Parallelism": 2
+    }
+  ]
+}

--- a/src/setup/building/builder.go
+++ b/src/setup/building/builder.go
@@ -27,8 +27,8 @@ func (b *Builder) BuildFunction(provider string, functionName string, runtime st
 
 	functionPath := fmt.Sprintf("setup/deployment/raw-code/serverless/%s/%s", provider, functionName)
 	switch runtime {
-	case "java":
-		buildJava(functionPath)
+	case "java11":
+		buildJava(functionPath, functionName)
 	case "go1.x":
 		buildGolang(functionPath)
 	default:
@@ -41,9 +41,13 @@ func (b *Builder) BuildFunction(provider string, functionName string, runtime st
 }
 
 // buildJava builds the java zip artifact for serverless deployment using Gradle
-func buildJava(functionPath string) {
-	// TODO: Implement function.
-	log.Warn(functionPath)
+func buildJava(functionPath string, functionName string) string {
+	util.RunCommandAndLog(exec.Command("gradle", "buildZip", "-p", functionPath))
+
+	artifactPath := fmt.Sprintf("%s/%s.zip", artifactDir, functionName)
+	util.RunCommandAndLog(exec.Command("mv", "build/distributions/*.zip", artifactPath))
+
+	return artifactPath
 }
 
 // buildGolang builds the Golang binary for serverless deployment

--- a/src/setup/building/builder.go
+++ b/src/setup/building/builder.go
@@ -45,7 +45,7 @@ func buildJava(functionPath string, functionName string) string {
 	util.RunCommandAndLog(exec.Command("gradle", "buildZip", "-p", functionPath))
 
 	artifactPath := fmt.Sprintf("%s/%s.zip", artifactDir, functionName)
-	util.RunCommandAndLog(exec.Command("mv", "build/distributions/*.zip", artifactPath))
+	util.RunCommandAndLog(exec.Command("mv", fmt.Sprintf("%s/build/distributions/%s.zip", functionPath, functionName), artifactPath))
 
 	return artifactPath
 }

--- a/src/setup/building/builder.go
+++ b/src/setup/building/builder.go
@@ -44,7 +44,7 @@ func (b *Builder) BuildFunction(provider string, functionName string, runtime st
 func buildJava(functionPath string, functionName string) string {
 	util.RunCommandAndLog(exec.Command("gradle", "buildZip", "-p", functionPath))
 
-	artifactPath := fmt.Sprintf("%s/%s.zip", artifactDir, functionName)
+	artifactPath := fmt.Sprintf("%s/%s/%s.zip", artifactDir, functionName, functionName)
 	util.RunCommandAndLog(exec.Command("mv", fmt.Sprintf("%s/build/distributions/%s.zip", functionPath, functionName), artifactPath))
 
 	return artifactPath

--- a/src/setup/building/test/building_test.go
+++ b/src/setup/building/test/building_test.go
@@ -1,29 +1,43 @@
 package building
 
 import (
-	"github.com/stretchr/testify/assert"
 	"log"
 	"os"
 	"stellar/setup/building"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestBuildFunctionJava(t *testing.T) {
-	b := &building.Builder{}
-	b.BuildFunction("aws", "test/function/path", "java11")
+type BuildingTestSuite struct {
+	suite.Suite
 }
 
-func TestBuildFunctionGolang(t *testing.T) {
-	b := &building.Builder{}
-	err := os.Chdir("../../..") // so that BuildFunction generates binaries in the correct path relative to the /src directory
+func (s *BuildingTestSuite) SetupSuite() {
+	err := os.Chdir("../../..") // so that BuildFunction generates binaries in the correct path relative to the /src directory")
 	if err != nil {
 		log.Fatal("Failed to change to /src directory ")
 	}
-	b.BuildFunction("aws", "hellogo", "go1.x")
-	assert.FileExists(t, "setup/deployment/raw-code/serverless/aws/hellogo/main")
 }
 
-func TestBuildFunctionUnsupported(t *testing.T) {
+func (s *BuildingTestSuite) TestBuildFunctionJava() {
+	b := &building.Builder{}
+	b.BuildFunction("aws", "hellojava", "java11")
+	assert.FileExists(s.T(), "setup/artifacts/helloajva/hellojava.zip")
+}
+
+func (s *BuildingTestSuite) TestBuildFunctionGolang() {
+	b := &building.Builder{}
+	b.BuildFunction("aws", "hellogo", "go1.x")
+	assert.FileExists(s.T(), "setup/deployment/raw-code/serverless/aws/hellogo/main")
+}
+
+func (s *BuildingTestSuite) TestBuildFunctionUnsupported() {
 	b := &building.Builder{}
 	b.BuildFunction("mockProvider", "mockFunctionName", "unsupported")
+}
+
+func TestBuildingTestSuite(t *testing.T) {
+	suite.Run(t, new(BuildingTestSuite))
 }

--- a/src/setup/building/test/building_test.go
+++ b/src/setup/building/test/building_test.go
@@ -15,16 +15,19 @@ type BuildingTestSuite struct {
 }
 
 func (s *BuildingTestSuite) SetupSuite() {
-	err := os.Chdir("../../..") // so that BuildFunction generates binaries in the correct path relative to the /src directory")
-	if err != nil {
+	if err := os.Chdir("../../.."); err != nil { // so that BuildFunction generates binaries in the correct path relative to the /src directory")
 		log.Fatal("Failed to change to /src directory ")
+	}
+
+	if err := os.MkdirAll("setup/artifacts/hellojava", os.ModePerm); err != nil {
+		log.Fatal("Failed to create artifact directory for hellojava")
 	}
 }
 
 func (s *BuildingTestSuite) TestBuildFunctionJava() {
 	b := &building.Builder{}
 	b.BuildFunction("aws", "hellojava", "java11")
-	assert.FileExists(s.T(), "setup/artifacts/helloajva/hellojava.zip")
+	assert.FileExists(s.T(), "setup/artifacts/hellojava/hellojava.zip")
 }
 
 func (s *BuildingTestSuite) TestBuildFunctionGolang() {

--- a/src/setup/deployment/raw-code/serverless/aws/hellojava/build.gradle
+++ b/src/setup/deployment/raw-code/serverless/aws/hellojava/build.gradle
@@ -1,0 +1,60 @@
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+}
+
+repositories {
+    mavenLocal()
+    maven {
+        url = uri('https://repo.maven.apache.org/maven2/')
+    }
+}
+
+dependencies {
+    api 'com.amazonaws:aws-java-sdk-lambda:1.12.472'
+    api 'com.amazonaws:aws-lambda-java-core:1.2.2'
+    api 'com.amazonaws:aws-lambda-java-events:3.11.1'
+    api 'com.google.code.gson:gson:2.10.1'
+}
+
+group = 'org.hellojava'
+version = '1.0-SNAPSHOT'
+description = 'hellojava'
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from(components.java)
+        }
+    }
+}
+
+jar {
+	manifest {
+		attributes 'Main-Class': 'org.hellojava.Handler'
+	}
+}
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
+tasks.withType(Javadoc) {
+    options.encoding = 'UTF-8'
+}
+
+task buildZip(type: Zip) {
+	archiveFileName='hellojava.zip'
+    into('lib') {
+        from(jar)
+        from(configurations.runtimeClasspath)
+    }
+}
+
+task copyRuntimeDependencies(type: Copy) {
+    from configurations.runtimeClasspath
+    into 'build/dependency'
+}
+
+build.dependsOn copyRuntimeDependencies

--- a/src/setup/deployment/raw-code/serverless/aws/hellojava/src/main/java/org/hellojava/Handler.java
+++ b/src/setup/deployment/raw-code/serverless/aws/hellojava/src/main/java/org/hellojava/Handler.java
@@ -1,0 +1,57 @@
+package org.hellojava;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.time.Instant;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.google.gson.Gson;
+
+class ResponseEventBody {
+    String region;
+    String requestId;
+    String[] timestampChain;
+
+    public ResponseEventBody(String region, String requestId, String[] timestampChain) {
+        this.region = region;
+        this.requestId = requestId;
+        this.timestampChain = timestampChain;
+    }
+}
+
+public class Handler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>{
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent event, Context context)
+    {
+        Gson gson = new Gson();
+        int incrementLimit = Integer.parseInt(event.getQueryStringParameters().getOrDefault("incrementLimit", "0"));
+        this.simulateWork(incrementLimit);
+        String requestId = "no-context";
+        if (context != null) {
+            requestId = context.getAwsRequestId();
+        }
+
+        Instant now = Instant.now();
+        String[] timestampChain = new String[]{""+now.getEpochSecond()+now.getNano()};
+        ResponseEventBody resBody = new ResponseEventBody(System.getenv("AWS_REGION"), requestId, timestampChain);
+
+		Map<String, String> responseHeaders = new HashMap<>();
+		responseHeaders.put("Content-Type", "application/json");
+        APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent().withHeaders(responseHeaders);
+        response.setIsBase64Encoded(false);
+        response.setStatusCode(200);
+        response.setBody(gson.toJson(resBody));
+
+        return response;
+    }
+
+    public void simulateWork(int incrementLimit) {
+        int i = 0;
+        while (i < incrementLimit) {
+            i++;
+        }
+    }
+}

--- a/src/setup/run.go
+++ b/src/setup/run.go
@@ -103,6 +103,15 @@ func ProvisionFunctionsServerless(config Configuration) {
 		//TODO: generate the code
 		code_generation.GenerateCode(subExperiment.Function, config.Provider)
 
+		// Create folder in artifacts for the function
+		functionDirPath := fmt.Sprintf("setup/artifacts/%s", subExperiment.Function)
+		if _, err := os.Stat(functionDirPath); os.IsNotExist(err) {
+			log.Info("Creating directory for function " + subExperiment.Function + "...")
+			if err := os.MkdirAll(functionDirPath, os.ModePerm); err != nil {
+				log.Fatalf("Error creating directory for function %s: %s", subExperiment.Function, err.Error())
+			}
+		}
+
 		// TODO: build the functions (Java and Golang)
 		artifactPath := builder.BuildFunction(config.Provider, subExperiment.Function, subExperiment.Runtime)
 		slsConfig.AddFunctionConfig(&subExperiment, index, artifactPath)


### PR DESCRIPTION
This PR implements the functionality to build java functions into zip artifacts and puts them into `src/setup/artifacts/<functionName>/<artifact>.zip`.

## Changes
- Add hellojava function code directory
- Add creation of `src/setup/artifacts/<functionName>/` folder
- Implement `buildJava()` in `builder.go` that uses gradle to build the zip artifact and move it into the artifact folder
- Update `building_test.go` to use a test suite; this allows for a 1-time setup before the tests run (Change shell dir, create artifacts dir, etc).
- Update test for buildJava()
- Add experiment JSON file for hellojava