### PR TITLE
Hellojava trigger fix

### DIFF
--- a/src/setup/deployment/raw-code/serverless/aws/hellojava/src/main/java/org/hellojava/Handler.java
+++ b/src/setup/deployment/raw-code/serverless/aws/hellojava/src/main/java/org/hellojava/Handler.java
@@ -27,7 +27,10 @@ public class Handler implements RequestHandler<APIGatewayProxyRequestEvent, APIG
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent event, Context context)
     {
         Gson gson = new Gson();
-        int incrementLimit = Integer.parseInt(event.getQueryStringParameters().getOrDefault("incrementLimit", "0"));
+	int incrementLimit = 0;
+	if (event.getQueryStringParameters() != null) {
+        	incrementLimit = Integer.parseInt(event.getQueryStringParameters().getOrDefault("incrementLimit", "0"));
+	}
         this.simulateWork(incrementLimit);
         String requestId = "no-context";
         if (context != null) {
@@ -38,8 +41,8 @@ public class Handler implements RequestHandler<APIGatewayProxyRequestEvent, APIG
         String[] timestampChain = new String[]{""+now.getEpochSecond()+now.getNano()};
         ResponseEventBody resBody = new ResponseEventBody(System.getenv("AWS_REGION"), requestId, timestampChain);
 
-		Map<String, String> responseHeaders = new HashMap<>();
-		responseHeaders.put("Content-Type", "application/json");
+	Map<String, String> responseHeaders = new HashMap<>();
+	responseHeaders.put("Content-Type", "application/json");
         APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent().withHeaders(responseHeaders);
         response.setIsBase64Encoded(false);
         response.setStatusCode(200);


### PR DESCRIPTION
This PR modifies the hellojava function code to prevent internal failure when the request body sent is empty when triggering the function.

## Changes
- Prevent null exception in function code when empty request body is sent

