### PR TITLE
Add SnapStart functionality for Java functions

### DIFF
--- a/.github/workflows/feature-serverless-framework-deployment.yml
+++ b/.github/workflows/feature-serverless-framework-deployment.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: AWS end-to-end test for Java
         working-directory: ${{env.working-directory}}
-        run: ./main --o latency-samples --c ../experiments/tests/aws/hellojava.json --s true
+        run: ./main --o latency-samples --c ../experiments/tests/aws/hellojava-snapstart.json --s true
 
   unit_tests:
     name: Unit tests

--- a/experiments/tests/aws/hellojava-snapstart.json
+++ b/experiments/tests/aws/hellojava-snapstart.json
@@ -1,0 +1,36 @@
+{
+  "Sequential": false,
+  "Provider": "aws",
+  "Runtime": "java11",
+  "SubExperiments": [
+    {
+      "Title": "snapstart_enabled",
+      "Function": "hellojava",
+	  "Handler": "org.hellojava.Handler",
+	  "PackageType": "Zip",
+	  "SnapStartEnabled": true,
+      "Bursts": 2,
+      "BurstSizes": [
+        2
+      ],
+      "DesiredServiceTimes": [
+        "0ms"
+      ],
+      "FunctionImageSizeMB": 24
+    },
+    {
+      "Title": "snapstart_disabled",
+      "Function": "hellojava",
+	  "Handler": "org.hellojava.Handler",
+	  "PackageType": "Zip",
+      "Bursts": 2,
+      "BurstSizes": [
+        2
+      ],
+      "DesiredServiceTimes": [
+        "0ms"
+      ],
+      "FunctionImageSizeMB": 24
+    }
+  ]
+}

--- a/src/setup/extract-configuration.go
+++ b/src/setup/extract-configuration.go
@@ -63,6 +63,7 @@ type SubExperiment struct {
 	StorageTransfer         bool     `json:"StorageTransfer"`
 	Handler                 string   `json:"Handler"`
 	Runtime                 string   `json:"Runtime"`
+	SnapStartEnabled        bool     `json:"SnapStartEnabled`
 	PackagePattern          string   `json:"PackagePattern"`
 	// All of the below are computed after reading the configuration
 	BusySpinIncrements []int64 `json:"BusySpinIncrements"`

--- a/src/setup/extract-configuration.go
+++ b/src/setup/extract-configuration.go
@@ -63,7 +63,7 @@ type SubExperiment struct {
 	StorageTransfer         bool     `json:"StorageTransfer"`
 	Handler                 string   `json:"Handler"`
 	Runtime                 string   `json:"Runtime"`
-	SnapStartEnabled        bool     `json:"SnapStartEnabled`
+	SnapStartEnabled        bool     `json:"SnapStartEnabled"`
 	PackagePattern          string   `json:"PackagePattern"`
 	// All of the below are computed after reading the configuration
 	BusySpinIncrements []int64 `json:"BusySpinIncrements"`

--- a/src/setup/serverless-config.go
+++ b/src/setup/serverless-config.go
@@ -32,11 +32,12 @@ type Package struct {
 }
 
 type Function struct {
-	Handler string          `yaml:"handler"`
-	Runtime string          `yaml:"runtime"`
-	Name    string          `yaml:"name"`
-	Events  []Event         `yaml:"events"`
-	Package FunctionPackage `yaml:"package"`
+	Handler   string          `yaml:"handler"`
+	Runtime   string          `yaml:"runtime"`
+	Name      string          `yaml:"name"`
+	Events    []Event         `yaml:"events"`
+	Package   FunctionPackage `yaml:"package"`
+	SnapStart bool            `yaml:"snapStart,omitempty"`
 }
 
 type FunctionPackage struct {
@@ -101,6 +102,9 @@ func (s *Serverless) AddFunctionConfig(subex *SubExperiment, index int, artifact
 		f.AddPackagePattern(subex.PackagePattern)
 		if artifactPath != "" {
 			f.Package.Artifact = artifactPath
+		}
+		if subex.SnapStartEnabled { // Add SnapStart field only if it is enabled
+			f.SnapStart = true
 		}
 		s.Functions[name] = f
 		subex.AddRoute(name)

--- a/src/setup/test/serverless-config_test.go
+++ b/src/setup/test/serverless-config_test.go
@@ -125,6 +125,58 @@ func TestCreateServerlessConfigFile(t *testing.T) {
 
 }
 
+func TestCreateServerlessConfigFileSnapStart(t *testing.T) {
+	assert := require.New(t)
+
+	// Define the expected Serverless struct
+	serverless := &setup.Serverless{
+		Service:          "TestService",
+		FrameworkVersion: "3",
+		Provider: setup.Provider{
+			Name:    "aws",
+			Runtime: "java11",
+			Region:  "us-west-1",
+		},
+		Package: setup.Package{
+			Individually: true,
+		},
+		Functions: map[string]*setup.Function{
+			"testFunction1": {
+				Handler:   "org.hellojava.Handler",
+				Runtime:   "java11",
+				Name:      "parallelism1_0_0",
+				SnapStart: true,
+				Package: setup.FunctionPackage{
+					Patterns: []string{},
+				},
+				Events: []setup.Event{
+					{
+						HttpApi: setup.HttpApi{
+							Path:   "/parallelism1_0_0",
+							Method: "GET",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Call the CreateServerlessConfigFile function
+	serverless.CreateServerlessConfigFile("serverless.yml")
+
+	// Read the contents of the generated YAML file
+	actualData, err := os.ReadFile("serverless.yml")
+	assert.NoError(err, "Error reading actual data")
+
+	// Generate YAML content from the expected Serverless struct
+	expectedData, err := os.ReadFile("test_snapstart.yml")
+	assert.NoError(err, "Error marshaling expected data")
+
+	// Compare the contents byte by byte
+	assert.True(bytes.Equal(expectedData, actualData), "YAML content mismatch")
+
+}
+
 // If this test is failing on your local machine, try running it with sudo.
 func TestDeployAndRemoveService(t *testing.T) {
 	// The two unit tests were merged together in order to make sure we are not left with a number of deployed test function on the cloud which are never used in.

--- a/src/setup/test/test_snapstart.yml
+++ b/src/setup/test/test_snapstart.yml
@@ -1,0 +1,21 @@
+service: TestService
+frameworkVersion: "3"
+provider:
+    name: aws
+    runtime: java11
+    region: us-west-1
+package:
+    individually: true
+functions:
+    testFunction1:
+        handler: org.hellojava.Handler
+        runtime: java11
+        name: parallelism1_0_0
+        events:
+            - httpApi:
+                path: /parallelism1_0_0
+                method: GET
+        package:
+            patterns:
+                - '**'
+        snapStart: true

--- a/src/setup/test/test_snapstart.yml
+++ b/src/setup/test/test_snapstart.yml
@@ -16,6 +16,5 @@ functions:
                 path: /parallelism1_0_0
                 method: GET
         package:
-            patterns:
-                - '**'
+            patterns: []
         snapStart: true


### PR DESCRIPTION
This PR together with #278 resolves #261, adding SnapStart functionality to Serverless Framework deployments for AWS.

## Changes
- Add `hellojava-snapstart.json` experiment JSON file that runs 2 functions, one with SnapStart enabled and one without
- Add `SnapStartEnabled` field to `SubExperiment` struct (To be enabled by user in experiment JSON files)
- Add `SnapStart` field to `Function` struct in `serverless-config.go`
- Add `TestCreateServerlessConfigFileSnapStart` for testing creation of serverless.yml file with snapStart field
- Add `test_snapstart.yml` file for checking expected value in `TestCreateServerlessConfigFileSnapStart` test
