### PR TITLE
filler files for Java artifacts

### DIFF
--- a/.github/workflows/feature-serverless-framework-deployment.yml
+++ b/.github/workflows/feature-serverless-framework-deployment.yml
@@ -102,6 +102,10 @@ jobs:
         working-directory: ${{env.working-directory}}
         run: ./main --o latency-samples --c ../experiments/tests/aws/hellopy.json --s true
 
+      - name: AWS end-to-end test for Go
+        working-directory: ${{env.working-directory}}
+        run: ./main --o latency-samples --c ../experiments/tests/aws/hellogo.json --s true
+
       - name: AWS end-to-end test for Java
         working-directory: ${{env.working-directory}}
         run: ./main --o latency-samples --c ../experiments/tests/aws/hellojava.json --s true

--- a/src/setup/deployment/packaging/test/zip_test.go
+++ b/src/setup/deployment/packaging/test/zip_test.go
@@ -61,6 +61,17 @@ func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsGolang() {
 	assert.InDelta(s.T(), 50, util.BytesToMB(fileInfo.Size()), 0.1)
 }
 
+func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsJava() {
+	b := &building.Builder{}
+	b.BuildFunction("aws", "hellojava", "java11")
+	packaging.GenerateServerlessZIPArtifacts(3, "aws", "java11", "hellojava", 50)
+	fileInfo, err := os.Stat("setup/deployment/raw-code/serverless/aws/artifacts/hellojava/hellojava.zip")
+	if err != nil {
+		assert.Fail(s.T(), "Could not obtain file info of ZIP artifact")
+	}
+	assert.InDelta(s.T(), 50, util.BytesToMB(fileInfo.Size()), 0.1)
+}
+
 func TestZipTestSuite(t *testing.T) {
 	suite.Run(t, new(ZipTestSuite))
 }


### PR DESCRIPTION
Resolves #255, together with previous PR of #276. Filler files are added to a pre-existing ZIP containing Java bytecode, built by Gradle in the previous build step. Also added missing e2e test for Go.