### PR TITLE
adjust hellojava snapstart experiment function image size

### DIFF
--- a/experiments/tests/aws/hellojava-snapstart.json
+++ b/experiments/tests/aws/hellojava-snapstart.json
@@ -16,7 +16,7 @@
       "DesiredServiceTimes": [
         "0ms"
       ],
-      "FunctionImageSizeMB": 24
+      "FunctionImageSizeMB": 36
     },
     {
       "Title": "snapstart_disabled",
@@ -30,7 +30,7 @@
       "DesiredServiceTimes": [
         "0ms"
       ],
-      "FunctionImageSizeMB": 24
+      "FunctionImageSizeMB": 48
     }
   ]
 }


### PR DESCRIPTION
We have a failing e2e test for hellojava with SnapStart on the `feature-serverless-framework-deployment` branch after my PR was merged. I believe it is because the `FunctionImageSizeMB` parameter in the experiment JSON config is set to a value that is too low, below the size of the actual artifact built by Gradle, even before filler files are generated. I made a small adjustment to increase that value.