### PR TITLE
Refactor cicd test pipeline for immediate results.

### DIFF
--- a/.github/workflows/feature-serverless-framework-deployment.yml
+++ b/.github/workflows/feature-serverless-framework-deployment.yml
@@ -55,6 +55,10 @@ jobs:
 
   unit_tests:
     name: Unit tests
+    strategy:
+      matrix:
+        path:
+          [./setup/test/..., ./benchmarking/..., ./util/..., ./setup/building/test/..., ./setup/code-generation/test/..., ./setup/deployment/packaging/test/..., ./setup/deployment/connection/...]
     needs: [ build_client ]
     runs-on: ubuntu-22.04
     env:
@@ -84,33 +88,9 @@ jobs:
         working-directory: ${{env.working-directory}}
         run: tar --strip-components=1 -xvf ../build.tar -C .
 
-      - name: Unit tests setup
+      - name: Unit tests
         working-directory: ${{env.working-directory}}
-        run: go test -short -v ./setup/test/...
-
-      - name: Unit tests benchmarking
-        working-directory: ${{env.working-directory}}
-        run: go test -short -v ./benchmarking/...
-
-      - name: Unit tests util
-        working-directory: ${{env.working-directory}}
-        run: go test -short -v ./util/...
-
-      - name: Unit tests building
-        working-directory: ${{env.working-directory}}
-        run: go test -short -v ./setup/building/test/...
-
-      - name: Unit tests code-generation
-        working-directory: ${{env.working-directory}}
-        run: go test -short -v ./setup/code-generation/test/...
-
-      - name: Unit tests packaging
-        working-directory: ${{env.working-directory}}
-        run: go test -short -v ./setup/deployment/packaging/test/...
-
-      - name: Unit tests connection
-        working-directory: ${{env.working-directory}}
-        run: go test -short -v ./setup/deployment/connection/...
+        run: go test -short -v ${{matrix.path}}
 
   integration_aws:
     name: Integration test

--- a/.github/workflows/feature-serverless-framework-deployment.yml
+++ b/.github/workflows/feature-serverless-framework-deployment.yml
@@ -53,9 +53,118 @@ jobs:
           path: build.tar
           retention-days: 1
 
+  unit_tests:
+    name: Unit tests
+    needs: [ build_client ]
+    runs-on: ubuntu-22.04
+    env:
+      working-directory: ./src
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials using EASE lab account
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: us-west-1
+
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.21
+
+      - name: Download client artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: STeLLAR-build
+
+      - name: Untar client build
+        working-directory: ${{env.working-directory}}
+        run: tar --strip-components=1 -xvf ../build.tar -C .
+
+      - name: Unit tests setup
+        working-directory: ${{env.working-directory}}
+        run: go test -short -v ./setup/test/...
+
+      - name: Unit tests benchmarking
+        working-directory: ${{env.working-directory}}
+        run: go test -short -v ./benchmarking/...
+
+      - name: Unit tests util
+        working-directory: ${{env.working-directory}}
+        run: go test -short -v ./util/...
+
+      - name: Unit tests building
+        working-directory: ${{env.working-directory}}
+        run: go test -short -v ./setup/building/test/...
+
+      - name: Unit tests code-generation
+        working-directory: ${{env.working-directory}}
+        run: go test -short -v ./setup/code-generation/test/...
+
+      - name: Unit tests packaging
+        working-directory: ${{env.working-directory}}
+        run: go test -short -v ./setup/deployment/packaging/test/...
+
+      - name: Unit tests connection
+        working-directory: ${{env.working-directory}}
+        run: go test -short -v ./setup/deployment/connection/...
+
+  integration_aws:
+    name: Integration test
+    needs: [build_client]
+    runs-on: ubuntu-22.04
+    env:
+      working-directory: ./src
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials using EASE lab account
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: us-west-1
+
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.21
+
+      - name: Set up Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+
+      - name: Install serverless framework
+        run: npm install -g serverless
+
+      - name: Download client artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: STeLLAR-build
+
+      - name: Untar client build
+        working-directory: ${{env.working-directory}}
+        run: tar --strip-components=1 -xvf ../build.tar -C .
+
+      - name: Prepare benchmarking functions
+        run: |
+          mkdir -p "setup/deployment/raw-code"
+          cp -R ./src/setup/deployment/raw-code/functions setup/deployment/raw-code/functions
+          mkdir -p "./src/latency-samples"
+
+      - name: Serverless framework integration tests
+        working-directory: ${{env.working-directory}}
+        run: go test -short -v ./setup/integration-test/...
+
+
   e2e_aws:
     name: AWS e2e test
-    needs: [build_client]
+    needs: [build_client, integration_aws]
     runs-on: ubuntu-22.04
     env:
       working-directory: ./src
@@ -110,69 +219,3 @@ jobs:
         working-directory: ${{env.working-directory}}
         run: ./main --o latency-samples --c ../experiments/tests/aws/hellojava-snapstart.json --s true
 
-  unit_tests:
-    name: Unit tests
-    needs: [ build_client, e2e_aws ]
-    runs-on: ubuntu-22.04
-    env:
-      working-directory: ./src
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Configure AWS credentials using EASE lab account
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: us-west-1
-
-      - name: Set up Go 1.21
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.21
-
-      - name: Set up Node.js 14.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-
-      - name: Install serverless framework
-        run: npm install -g serverless
-
-      - name: Download client artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: STeLLAR-build
-
-      - name: Untar client build
-        working-directory: ${{env.working-directory}}
-        run: tar --strip-components=1 -xvf ../build.tar -C .
-
-      - name: Unit tests setup
-        working-directory: ${{env.working-directory}}
-        run: go test -short -v ./setup/test/...
-
-      - name: Unit tests benchmarking
-        working-directory: ${{env.working-directory}}
-        run: go test -short -v ./benchmarking/...
-
-      - name: Unit tests util
-        working-directory: ${{env.working-directory}}
-        run: go test -short -v ./util/...
-
-      - name: Unit tests building
-        working-directory: ${{env.working-directory}}
-        run: go test -short -v ./setup/building/test/...
-
-      - name: Unit tests code-generation
-        working-directory: ${{env.working-directory}}
-        run: go test -short -v ./setup/code-generation/test/...
-
-      - name: Unit tests packaging
-        working-directory: ${{env.working-directory}}
-        run: go test -short -v ./setup/deployment/packaging/test/...
-
-      - name: Unit tests connection
-        working-directory: ${{env.working-directory}}
-        run: go test -short -v ./setup/deployment/connection/...

--- a/src/setup/integration-test/serverless-config_test.go
+++ b/src/setup/integration-test/serverless-config_test.go
@@ -1,0 +1,28 @@
+package setup
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"os/exec"
+	"stellar/setup"
+	"stellar/util"
+	"strings"
+	"testing"
+)
+
+// If this test is failing on your local machine, try running it with sudo.
+func TestDeployAndRemoveService(t *testing.T) {
+	// The two unit tests were merged together in order to make sure we are not left with a number of deployed test function on the cloud which are never used in.
+	util.RunCommandAndLog(exec.Command("cp", "test.yml", "../deployment/raw-code/serverless/aws/serverless.yml"))
+
+	msgDeploy := setup.DeployService("../deployment/raw-code/serverless/aws/")
+
+	linesDeploy := len(strings.Split(msgDeploy, "\n"))
+
+	msgRemove := setup.RemoveService("../deployment/raw-code/serverless/aws/")
+	linesRemove := len(strings.Split(msgRemove, "\n"))
+	log.Info(msgDeploy)
+	log.Info(msgRemove)
+	require.Equal(t, 5, linesDeploy)
+	require.Equal(t, 1, linesRemove)
+}

--- a/src/setup/integration-test/test.yml
+++ b/src/setup/integration-test/test.yml
@@ -1,0 +1,20 @@
+service: TestService
+frameworkVersion: "3"
+provider:
+    name: aws
+    runtime: python3.9
+    region: us-west-1
+package:
+    individually: true
+functions:
+    testFunction1:
+        handler: hellopy/lambda_function.lambda_handler
+        runtime: python3.9
+        name: parallelism1_0_0
+        events:
+            - httpApi:
+                path: /parallelism1_0_0
+                method: GET
+        package:
+            patterns:
+                - hellopy/lambda_function.py

--- a/src/setup/test/serverless-config_test.go
+++ b/src/setup/test/serverless-config_test.go
@@ -2,13 +2,9 @@ package setup
 
 import (
 	"bytes"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"os"
-	"os/exec"
 	"stellar/setup"
-	"stellar/util"
-	"strings"
 	"testing"
 )
 
@@ -175,23 +171,6 @@ func TestCreateServerlessConfigFileSnapStart(t *testing.T) {
 	// Compare the contents byte by byte
 	assert.True(bytes.Equal(expectedData, actualData), "YAML content mismatch")
 
-}
-
-// If this test is failing on your local machine, try running it with sudo.
-func TestDeployAndRemoveService(t *testing.T) {
-	// The two unit tests were merged together in order to make sure we are not left with a number of deployed test function on the cloud which are never used in.
-	util.RunCommandAndLog(exec.Command("cp", "test.yml", "../deployment/raw-code/serverless/aws/serverless.yml"))
-
-	msgDeploy := setup.DeployService("../deployment/raw-code/serverless/aws/")
-
-	linesDeploy := len(strings.Split(msgDeploy, "\n"))
-
-	msgRemove := setup.RemoveService("../deployment/raw-code/serverless/aws/")
-	linesRemove := len(strings.Split(msgRemove, "\n"))
-	log.Info(msgDeploy)
-	log.Info(msgRemove)
-	require.Equal(t, 5, linesDeploy)
-	require.Equal(t, 1, linesRemove)
 }
 
 func TestAddPackagePattern(t *testing.T) {


### PR DESCRIPTION
- Separate integration tests from unit tests. Integration tests engage with the serverless.com framework. The reason from making these tests separate from unit tests is to save the testing time by running more test in parallel.
- It is not good practice to have two serverless.com workers deploying to th esame cloud. It makes the deployment get stuck in a certain phase, the processs fails, and requires manual intervention. (However, deploying through APIs while deploying through serverless.com does not seem to cause trouble).

- We run unit tests in parallel with integration and e2e test (e2e and integration are run in series). This gives the developer faster feedback and also reduces overall testing time, while avoiding serverless.com clashes.