### PR TITLE
Update RemoveService function

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -83,7 +83,7 @@ func main() {
 		benchmarking.TriggerSubExperiments(config, outputDirectoryPath, *specificExperimentFlag)
 
 		log.Info("Starting functions removal from cloud.")
-		setup.RemoveService(config.Provider, serverlessDirPath, len(config.SubExperiments))
+		setup.RemoveService(&config, serverlessDirPath)
 	} else {
 		setup.ProvisionFunctions(config)
 		benchmarking.TriggerSubExperiments(config, outputDirectoryPath, *specificExperimentFlag)

--- a/src/setup/integration-test/serverless-config_test.go
+++ b/src/setup/integration-test/serverless-config_test.go
@@ -23,7 +23,8 @@ func TestDeployAndRemoveServiceAWS(t *testing.T) {
 	assert.True(strings.Contains(msgRemove, "successfully removed"))
 }
 
-func TestDeployAndRemoveContainerService(t *testing.T) {
+func TestDeployAndRemoveServiceGCR(t *testing.T) {
+	assert := require.New(t)
 	s := &setup.Serverless{
 		Service:          "STeLLAR",
 		FrameworkVersion: "3",
@@ -35,13 +36,13 @@ func TestDeployAndRemoveContainerService(t *testing.T) {
 	}
 
 	subex := &setup.SubExperiment{
-		Title:       "test_hellopy",
+		Title:       "hellopytest",
 		Parallelism: 1,
 	}
 
 	s.DeployGCRContainerService(subex, 0, "docker.io/kkmin/hellopy", "../deployment/raw-code/serverless/gcr/hellopy/", "us-west1")
-	deleteMsg := setup.RemoveService("gcr", "../deployment/raw-code/serverless/gcr/hellopy/", 1)
-	require.Equal(t, "All GCR services deleted.", deleteMsg)
+	deleteMsg := setup.RemoveGCRSingleService("hellopytest-0-0")
+	assert.True(strings.Contains(deleteMsg, "Deleted service [hellopytest-0-0]"))
 }
 
 func TestDeployAndRemoveServiceAzure(t *testing.T) {

--- a/src/setup/serverless-config.go
+++ b/src/setup/serverless-config.go
@@ -178,7 +178,7 @@ func (s *Serverless) CreateServerlessConfigFile(path string) {
 	}
 }
 
-// RemoveService removes the service defined in serverless.yml
+// RemoveService removes the services created by experiments
 func RemoveService(config *Configuration, path string) string {
 	switch config.Provider {
 	case "aws":
@@ -230,6 +230,7 @@ func RemoveAzureSingleService(path string) string {
 	return slsRemoveCmdOutput
 }
 
+// RemoveGCRAllServices removes all GCR services defined in the Subexperiment array
 func RemoveGCRAllServices(subExperiments []SubExperiment) []string {
 	var deleteServiceMessages []string
 	for index, subex := range subExperiments {
@@ -242,6 +243,7 @@ func RemoveGCRAllServices(subExperiments []SubExperiment) []string {
 	return deleteServiceMessages
 }
 
+// RemoveGCRSingleService removes a single GCR service
 func RemoveGCRSingleService(service string) string {
 	log.Infof("Deleting GCR service %s...", service)
 	deleteServiceCommand := exec.Command("gcloud", "run", "services", "delete", "--quiet", "--region", GCR_DEFAULT_REGION, service)

--- a/src/setup/test/serverless-config_test.go
+++ b/src/setup/test/serverless-config_test.go
@@ -263,8 +263,14 @@ func TestGetAWSEndpointIdMultipleFunctions(t *testing.T) {
 	require.Equal(t, "z4a0lmtx64", actual)
 }
 
-func TestGetEndpointIdAzure(t *testing.T) {
+func TestGetAzureEndpointID(t *testing.T) {
 	testMsg := "Deployed serverless functions:\n-> subexperiment2_1_0: [GET] sls-seasi-dev-stellar-sub-experiment-1.azurewebsites.net/api/subexperiment2_1_0\n-> subexperiment2_1_1: [GET] sls-seasi-dev-stellar-sub-experiment-1.azurewebsites.net/api/subexperiment2_1_1\n"
 	actual := setup.GetAzureEndpointID(testMsg)
 	require.Equal(t, "sls-seasi-dev-stellar-sub-experiment-1", actual)
+}
+
+func TestGetGCREndpointID(t *testing.T) {
+	testMsg := "Service [test-function] revision [test-function-00001-cec] has been deployed and is serving 100 percent of traffic.\nService URL: https://test-function-nfjrndgaha-uw.a.run.app"
+	actual := setup.GetGCREndpointID(testMsg)
+	require.Equal(t, "test-function-nfjrndgaha-uw.a.run.app", actual)
 }


### PR DESCRIPTION
Update `RemoveService` function for consistency across different providers as well as update GCR service removal functions to be more precise.

## Changes
- Update `RemoveService` function signature to receive `config *Configuration` as the input; args that different providers need for function removal can be obtained from this object
- Update GCR Removal services to be consistent with Azure removal: Add `RemoveGCRAllServices` and `RemoveGCRSingleService`
- Update integration test for GCR