### PR TITLE
add support for Alibaba Cloud

### DIFF
--- a/.github/workflows/feature-serverless-framework-deployment.yml
+++ b/.github/workflows/feature-serverless-framework-deployment.yml
@@ -147,6 +147,19 @@ jobs:
         with:
           version: ">= 363.0.0"
 
+      - name: Set up Alibaba Cloud credentials
+        run: |
+          mkdir $HOME/.aliyuncli
+          echo "[default]" > $HOME/.aliyuncli/credentials
+          echo "aliyun_access_key_secret = $ALIYUN_ACCESS_KEY_SECRET" >> $HOME/.aliyuncli/credentials
+          echo "aliyun_access_key_id = $ALIYUN_ACCESS_KEY_ID" >> $HOME/.aliyuncli/credentials
+          echo "aliyun_account_id = $ALIYUN_ACCOUNT_ID" >> $HOME/.aliyuncli/credentials
+          echo "" >> $HOME/.aliyuncli/credentials
+        env:
+          ALIYUN_ACCESS_KEY_SECRET: ${{ secrets.ALIYUN_ACCESS_KEY_SECRET }}
+          ALIYUN_ACCESS_KEY_ID: ${{ secrets.ALIYUN_ACCESS_KEY_ID }}
+          ALIYUN_ACCOUNT_ID: ${{ secrets.ALIYUN_ACCOUNT_ID }}
+
       - name: Set up Go 1.21
         uses: actions/setup-go@v2
         with:
@@ -159,7 +172,7 @@ jobs:
 
       - name: Install Serverless framework and related plugins
         # functions-have-names appears to be a dependency of serverless-azure-functions
-        run: npm install -g serverless serverless-azure-functions functions-have-names
+        run: npm install -g serverless serverless-azure-functions functions-have-names serverless-aliyun-function-compute
 
       - name: Install Cloudflare Wrangler
         run: npm install -g wrangler
@@ -183,6 +196,65 @@ jobs:
         working-directory: ${{env.working-directory}}
         run: go test -short -v ./setup/integration-test/... -timeout 30m
 
+  e2e_alibaba:
+    name: Alibaba Cloud e2e test
+    needs: [ build_client, integration_tests ]
+    runs-on: ubuntu-22.04
+    env:
+      working-directory: ./src
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Set up Alibaba Cloud CLI
+        uses: aliyun/setup-aliyun-cli-action@v1
+
+      - name: Set up Alibaba Cloud credentials
+        run: |
+          mkdir $HOME/.aliyuncli
+          echo "[default]" > $HOME/.aliyuncli/credentials
+          echo "aliyun_access_key_secret = $ALIYUN_ACCESS_KEY_SECRET" >> $HOME/.aliyuncli/credentials
+          echo "aliyun_access_key_id = $ALIYUN_ACCESS_KEY_ID" >> $HOME/.aliyuncli/credentials
+          echo "aliyun_account_id = $ALIYUN_ACCOUNT_ID" >> $HOME/.aliyuncli/credentials
+          echo "" >> $HOME/.aliyuncli/credentials
+          aliyun configure set --region us-west-1
+        env:
+          ALIYUN_ACCESS_KEY_SECRET: ${{ secrets.ALIYUN_ACCESS_KEY_SECRET }}
+          ALIYUN_ACCESS_KEY_ID: ${{ secrets.ALIYUN_ACCESS_KEY_ID }}
+          ALIYUN_ACCOUNT_ID: ${{ secrets.ALIYUN_ACCOUNT_ID }}
+
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.21
+
+      - name: Set up Node.js 16.16.0
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.16.0
+
+      - name: Install Serverless framework and related plugins
+        run: npm install -g serverless serverless-aliyun-function-compute
+
+      - name: Download client artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: STeLLAR-build
+
+      - name: Untar client build
+        working-directory: ${{env.working-directory}}
+        run: tar --strip-components=1 -xvf ../build.tar -C .
+
+      - name: Prepare benchmarking functions
+        run: |
+          mkdir -p "setup/deployment/raw-code"
+          cp -R ./src/setup/deployment/raw-code/functions setup/deployment/raw-code/functions
+          mkdir -p "./src/latency-samples"
+
+      - name: Alibaba Cloud end-to-end test for Python
+        working-directory: ${{env.working-directory}}
+        run: ./main --o latency-samples --c ../experiments/tests/aliyun/hellopy.json --s true
+
   e2e_azure:
     name: Azure e2e test
     needs: [ build_client, integration_tests ]
@@ -198,10 +270,10 @@ jobs:
         with:
           go-version: 1.21
 
-      - name: Set up Node 18
+      - name: Set up Node.js 16.16.0
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16.16.0
 
       - name: Install Serverless framework and related plugins
         # functions-have-names appears to be a dependency of serverless-azure-functions
@@ -349,48 +421,48 @@ jobs:
         run: ./main --o latency-samples --c ../experiments/tests/gcr/hellogo.json --s true
 
   e2e_cloudflare:
-      name: Cloudflare e2e test
-      needs: [ build_client, integration_tests ]
-      runs-on: ubuntu-22.04
-      env:
-        working-directory: ./src
-        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      steps:
-        - name: Check out code into the Go module directory
-          uses: actions/checkout@v2
+    name: Cloudflare e2e test
+    needs: [ build_client, integration_tests ]
+    runs-on: ubuntu-22.04
+    env:
+      working-directory: ./src
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
 
-        - name: Set up Go 1.21
-          uses: actions/setup-go@v2
-          with:
-            go-version: 1.21
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.21
 
-        - name: Set up Node.js 16.16.0
-          uses: actions/setup-node@v3
-          with:
-            node-version: 16.16.0
+      - name: Set up Node.js 16.16.0
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.16.0
 
-        - name: Install Cloudflare Wrangler
-          run: npm install -g wrangler
+      - name: Install Cloudflare Wrangler
+        run: npm install -g wrangler
 
-        - name: Download client artifact
-          uses: actions/download-artifact@v2
-          with:
-            name: STeLLAR-build
+      - name: Download client artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: STeLLAR-build
 
-        - name: Untar client build
-          working-directory: ${{env.working-directory}}
-          run: tar --strip-components=1 -xvf ../build.tar -C .
+      - name: Untar client build
+        working-directory: ${{env.working-directory}}
+        run: tar --strip-components=1 -xvf ../build.tar -C .
 
-        - name: Prepare benchmarking functions
-          run: |
-            mkdir -p 'setup/deployment/raw-code'
-            cp -R ./src/setup/deployment/raw-code/functions setup/deployment/raw-code/functions
-            mkdir -p './src/latency-samples'
+      - name: Prepare benchmarking functions
+        run: |
+          mkdir -p 'setup/deployment/raw-code'
+          cp -R ./src/setup/deployment/raw-code/functions setup/deployment/raw-code/functions
+          mkdir -p './src/latency-samples'
 
-        - name: Cloudflare end-to-end test for Node
-          working-directory: ${{env.working-directory}}
-          run: ./main --o latency-samples --c ../experiments/tests/cloudflare/hellonode.json --s true
+      - name: Cloudflare end-to-end test for Node
+        working-directory: ${{env.working-directory}}
+        run: ./main --o latency-samples --c ../experiments/tests/cloudflare/hellonode.json --s true
 
-        - name: Cloudflare end-to-end test for Python
-          working-directory: ${{env.working-directory}}
-          run: ./main --o latency-samples --c ../experiments/tests/cloudflare/hellopy.json --s true
+      - name: Cloudflare end-to-end test for Python
+        working-directory: ${{env.working-directory}}
+        run: ./main --o latency-samples --c ../experiments/tests/cloudflare/hellopy.json --s true

--- a/experiments/tests/aliyun/hellopy.json
+++ b/experiments/tests/aliyun/hellopy.json
@@ -1,0 +1,38 @@
+{
+  "Sequential": false,
+  "Provider": "aliyun",
+  "Runtime": "python3.9",
+  "SubExperiments": [
+    {
+      "Title": "parallelism1",
+      "Function": "hellopy",
+	  "Handler": "main.main",
+	  "PackageType": "Zip",
+	  "PackagePattern": "main.py",
+      "Bursts": 2,
+      "BurstSizes": [
+        2
+      ],
+      "DesiredServiceTimes": [
+        "0ms"
+      ],
+      "FunctionImageSizeMB": 24
+    },
+    {
+      "Title": "parallelism2",
+      "Function": "hellopy",
+	  "Handler": "main.main",
+	  "PackageType": "Zip",
+	  "PackagePattern": "main.py",
+      "Bursts": 3,
+      "BurstSizes": [
+        4
+      ],
+      "DesiredServiceTimes": [
+        "0ms"
+      ],
+      "FunctionImageSizeMB": 48,
+      "Parallelism": 2
+    }
+  ]
+}

--- a/src/benchmarking/networking/benchhttp/functions.go
+++ b/src/benchmarking/networking/benchhttp/functions.go
@@ -84,6 +84,8 @@ func appendProducerConsumerParameters(provider string, request *http.Request, pa
 	case "cloudflare":
 	case "gcr":
 		break // there is no raw query for GCR and Cloudflare
+	case "aliyun":
+		request.URL.Path = fmt.Sprintf("/%s", route)
 	default:
 		log.Fatalf("Unrecognized provider %q", provider)
 	}

--- a/src/benchmarking/run.go
+++ b/src/benchmarking/run.go
@@ -109,6 +109,8 @@ func executeRequestAndWriteResults(requestsWaitGroup *sync.WaitGroup, provider s
 		fallthrough
 	case "cloudflare":
 		fallthrough
+	case "aliyun":
+		fallthrough
 	case "google":
 		request := benchhttp.CreateRequest(provider, payloadLengthBytes, gatewayEndpoint, incrementLimit, storageTransfer, route)
 		log.Debugf("Created HTTP request with URL (%q), Body (%q)", (*request).URL, (*request).Body)

--- a/src/setup/deployment/raw-code/serverless/aliyun/hellopy/main.py
+++ b/src/setup/deployment/raw-code/serverless/aliyun/hellopy/main.py
@@ -1,0 +1,32 @@
+import json
+import time
+
+
+def main(event, context):
+    event = json.loads(event)
+
+    increment_limit = 0
+    if "IncrementLimit" in event["queryParameters"]:
+        increment_limit = int(event["queryParameters"]["IncrementLimit"])
+    if "IncrementLimit" in event["body"]:
+        increment_limit = int(event["body"]["IncrementLimit"])
+    simulate_work(increment_limit)
+
+    response_body = {
+        "Region": context.region,
+        "RequestID": context.request_id,
+        "TimestampChain": [str(time.time_ns())],
+    }
+    response = {
+        "isBase64Encoded": "false",
+        "statusCode": "200",
+        "headers": {"x-custom-header": "no", "Content-Type": "application/json"},
+        "body": response_body,
+    }
+    return json.dumps(response)
+
+
+def simulate_work(increment_limit: int) -> None:
+    num = 0
+    while num < increment_limit:
+        num += 1

--- a/src/setup/integration-test/aliyun-integration-test-serverless.yml
+++ b/src/setup/integration-test/aliyun-integration-test-serverless.yml
@@ -1,0 +1,25 @@
+service: stellar-aliyun-itgr-test
+
+frameworkVersion: '3'
+
+provider:
+  name: aliyun
+  runtime: python3.9
+  credentials: ~/.aliyuncli/credentials # path must be absolute
+  region: us-west-1
+
+plugins:
+  - serverless-aliyun-function-compute
+
+functions:
+  hello:
+    handler: main.main
+    runtime: python3.9
+    package:
+      patterns:
+        - "!**"
+        - main.py
+    events:
+      - http:
+          path: /foo
+          method: get

--- a/src/setup/integration-test/serverless-config_test.go
+++ b/src/setup/integration-test/serverless-config_test.go
@@ -17,7 +17,7 @@ func TestDeployAndRemoveServiceAWS(t *testing.T) {
 	util.RunCommandAndLog(exec.Command("cp", "aws-integration-test-serverless.yml", "../deployment/raw-code/serverless/aws/serverless.yml"))
 
 	msgDeploy := setup.DeployService("../deployment/raw-code/serverless/aws/")
-	msgRemove := setup.RemoveAWSService("../deployment/raw-code/serverless/aws/")
+	msgRemove := setup.RemoveServerlessService("../deployment/raw-code/serverless/aws/")
 
 	assert.True(strings.Contains(msgDeploy, "Service deployed"))
 	assert.True(strings.Contains(msgRemove, "successfully removed"))
@@ -51,7 +51,7 @@ func TestDeployAndRemoveServiceAzure(t *testing.T) {
 	util.RunCommandAndLog(exec.Command("cp", "azure-integration-test-serverless.yml", "../deployment/raw-code/serverless/azure/hellopy/serverless.yml"))
 
 	msgDeploy := setup.DeployService("../deployment/raw-code/serverless/azure/hellopy/")
-	msgRemove := setup.RemoveAzureSingleService("../deployment/raw-code/serverless/azure/hellopy/")
+	msgRemove := setup.RemoveServerlessServiceForcefully("../deployment/raw-code/serverless/azure/hellopy/")
 
 	assert.True(strings.Contains(msgDeploy, "Deployed serverless functions"))
 	assert.True(strings.Contains(msgRemove, "successfully removed"))
@@ -71,4 +71,16 @@ func TestDeployAndRemoveServiceCloudflare(t *testing.T) {
 	msgRemove := setup.RemoveCloudflareSingleWorker("cloudflaretest-0-0")
 
 	assert.True(strings.Contains(msgRemove, "Successfully deleted"))
+}
+
+func TestDeployAndRemoveServiceAlibaba(t *testing.T) {
+	assert := require.New(t)
+
+	util.RunCommandAndLog(exec.Command("cp", "aliyun-integration-test-serverless.yml", "../deployment/raw-code/serverless/aliyun/hellopy/serverless.yml"))
+
+	msgDeploy := setup.DeployService("../deployment/raw-code/serverless/aliyun/hellopy/")
+	msgRemove := setup.RemoveServerlessService("../deployment/raw-code/serverless/aliyun/hellopy/")
+
+	assert.True(strings.Contains(msgDeploy, "Deployed API"))
+	assert.True(strings.Contains(msgRemove, "Removed service"))
 }

--- a/src/setup/test/serverless-config_test.go
+++ b/src/setup/test/serverless-config_test.go
@@ -46,7 +46,16 @@ func TestAddFunctionConfigAWS(t *testing.T) {
 					Artifact: "",
 				},
 				Events: []setup.Event{
-					{AWSHttpEvent: setup.AWSHttpEvent{Path: "/test1-2-0", Method: "GET"}}}},
+					{
+						AWSEvent: &setup.AWSEvent{
+							AWSHttpEvent: setup.AWSHttpEvent{
+								Path:   "/test1-2-0",
+								Method: "GET",
+							},
+						},
+					},
+				},
+			},
 			"test1-2-1": {
 				Name:    "test1-2-1",
 				Handler: "main.lambda_handler",
@@ -56,8 +65,18 @@ func TestAddFunctionConfigAWS(t *testing.T) {
 					Artifact: "",
 				},
 				Events: []setup.Event{
-					{AWSHttpEvent: setup.AWSHttpEvent{Path: "/test1-2-1", Method: "GET"}}}},
-		}}
+					{
+						AWSEvent: &setup.AWSEvent{
+							AWSHttpEvent: setup.AWSHttpEvent{
+								Path:   "/test1-2-1",
+								Method: "GET",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 
 	actual := &setup.Serverless{Package: setup.Package{Individually: true}}
 
@@ -82,9 +101,13 @@ func TestAddFunctionConfigAzure(t *testing.T) {
 				},
 				Events: []setup.Event{
 					{
-						AzureHttp:      true,
-						AzureMethods:   []string{"GET"},
-						AzureAuthLevel: "anonymous",
+						AzureEvent: &setup.AzureEvent{
+							AzureHttpEvent: setup.AzureHttpEvent{
+								AzureHttp:      true,
+								AzureMethods:   []string{"GET"},
+								AzureAuthLevel: "anonymous",
+							},
+						},
 					},
 				},
 			},
@@ -98,9 +121,13 @@ func TestAddFunctionConfigAzure(t *testing.T) {
 				},
 				Events: []setup.Event{
 					{
-						AzureHttp:      true,
-						AzureMethods:   []string{"GET"},
-						AzureAuthLevel: "anonymous",
+						AzureEvent: &setup.AzureEvent{
+							AzureHttpEvent: setup.AzureHttpEvent{
+								AzureHttp:      true,
+								AzureMethods:   []string{"GET"},
+								AzureAuthLevel: "anonymous",
+							},
+						},
 					},
 				},
 			},
@@ -142,9 +169,11 @@ func TestCreateServerlessConfigFile(t *testing.T) {
 				},
 				Events: []setup.Event{
 					{
-						AWSHttpEvent: setup.AWSHttpEvent{
-							Path:   "/parallelism1-0-0",
-							Method: "GET",
+						AWSEvent: &setup.AWSEvent{
+							AWSHttpEvent: setup.AWSHttpEvent{
+								Path:   "/parallelism1-0-0",
+								Method: "GET",
+							},
 						},
 					},
 				},
@@ -194,9 +223,11 @@ func TestCreateServerlessConfigFileSnapStart(t *testing.T) {
 				},
 				Events: []setup.Event{
 					{
-						AWSHttpEvent: setup.AWSHttpEvent{
-							Path:   "/parallelism1-0-0",
-							Method: "GET",
+						AWSEvent: &setup.AWSEvent{
+							AWSHttpEvent: setup.AWSHttpEvent{
+								Path:   "/parallelism1-0-0",
+								Method: "GET",
+							},
 						},
 					},
 				},
@@ -279,4 +310,10 @@ func TestGetCloudflareEndpointID(t *testing.T) {
 	testMsg := "Published hellojs_wrangler0 (3.48 sec)\nhttps://hellonode.stellarbench.workers.dev\nCurrent Deployment ID: 26923084-4e66-4b4b-b876-cb85341b75f6"
 	actual := setup.GetCloudflareEndpointID(testMsg)
 	require.Equal(t, "hellonode.stellarbench.workers.dev", actual)
+}
+
+func TestGetAlibabaEndpointID(t *testing.T) {
+	testMsg := "Deploying API sls_http_my_service_dev_hello...\nDeployed API sls_http_my_service_dev_hello\nGET http://5cfeb440ed6d4ad69ae29d8408aa606e-ap-southeast-1.alicloudapi.com/foo -> my-service-dev.my-service-dev-hello\n"
+	actual := setup.GetAlibabaEndpointID(testMsg)
+	require.Equal(t, "5cfeb440ed6d4ad69ae29d8408aa606e", actual)
 }


### PR DESCRIPTION
This PR resolves #299.

## Changes

- added hellopy raw code at `src/setup/deployment/raw-code/serverless/aliyun/hellopy/main.py` and experiment JSON configuration file at `experiments/tests/aliyun/hellopy.json`
- added and updated `Event` and related `AWSEvent`, `AWSHttpEvent`, `AzureEvent`, `AzureHttpEvent`, `AlibabaEvent`, `AlibabaHttpEvent` structs
- custom `MarshalYAML` method on `Event` struct to change its default YAML marshalling behaviour
- `GetAlibabaEndpointID` for obtaining Alibaba Cloud endpoints needed for experiments, along with corresponding unit tests
- integration and E2E tests for the deployment & removal of Alibaba Cloud service

## Possible Issues for Future Consideration

### Access Limits on default domains assigned by API Gateway

Default "second-level domain" that is automatically assigned by Alibaba Cloud for its API gateways can only be accessed 100 times in a day. A custom domain may be required for large experiments in the future.

### Fixed bucket name assigned by Serverless framework

Deployment to Alibaba Cloud through the Serverless framework is done with the help of the `serverless-aliyun-function-compute` plugin. The plugin always creates a single OSS deployment bucket with the exact same name, for a given Alibaba Cloud account, even across multiple Serverless services. This is problematic in the following scenario:
1. [Deploying Service A] Creates Bucket X
2. [Deploying Service A] Uploads code of Function A to Bucket X
3. [Deploying Service A] Creates Function A
4. [Deploying Service B] Bucket X exists, creation skipped
5. [Deploying Service B] Uploads code of Function B to Bucket X
6. [Deploying Service B] Creates Function B
7. [Removing Service A] Deletes Function A
8. [Removing Service A] Deletes code of Function A from Bucket X
9. [Removing Service A] FATAL ERROR: Tries to delete Bucket X, but code of function B still exists

I have attempted to circumvent this issue by using the Alibaba Cloud CLI to forcefully remove the bucket and all of its contents prior to the removal of all service i.e. between steps 6 and 7 listed above. I welcome any suggestions/advice on this.

I think this is not ideal and we may wish to consider switching to the CLI or SDK for deployments in the future, though that will require significantly more effort since independent resources, including OSS buckets, API gateways, RAM roles, and FC functions themselves have to be created separately.