### PR TITLE
Extend timeout for Integration tests

### DIFF
--- a/.github/workflows/feature-serverless-framework-deployment.yml
+++ b/.github/workflows/feature-serverless-framework-deployment.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Integration Tests
         working-directory: ${{env.working-directory}}
-        run: go test -short -v ./setup/integration-test/...
+        run: go test -short -v ./setup/integration-test/... -timeout 30m
 
   e2e_azure:
     name: Azure e2e test


### PR DESCRIPTION
Currently, integration tests are failing in the pipeline on `feature-serverless-framework-deployment` branch due to the 10 minute default timeout by Go tests; this PR extends the timeout to 30 minute to allow room for the integration tests to complete.

## Changes
- Add `-timeout 30m` flag option to go test command for integration tests in workflow