### PR TITLE
Update setup scripts

### DIFF
--- a/scripts/cloudflare/setup.sh
+++ b/scripts/cloudflare/setup.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
+# Install Wrangler CLI
+npm install -g wrangler --save-dev
+
 wrangler config

--- a/scripts/cloudflare/setup.sh
+++ b/scripts/cloudflare/setup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+wrangler config

--- a/scripts/gcr/setup.sh
+++ b/scripts/gcr/setup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+gcloud init

--- a/scripts/gcr/setup.sh
+++ b/scripts/gcr/setup.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
+# Install gcloud CLI
+sudo apt-get install google-cloud-cli
+
 gcloud init

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,48 @@
 #!/bin/bash
+sudo add-apt-repository ppa:longsleep/golang-backports
+sudo add-apt-repository ppa:linuxuprising/java
+sudo add-apt-repository ppa:cwchien/gradle
+sudo apt-get install apt-transport-https ca-certificates gnupg curl sudo
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 sudo apt-get update
+
+# Set up Docker Registry
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+echo \
+"deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+"$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# Install Docker Engine
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Install Golang
+sudo apt install golang
+
+# Install OpenJDK 11
+sudo apt-get install openjdk-11-jdk
+
+# Install Gradle
+sudo apt install gradle
+
+# Install Node
+NODE_MAJOR=16
+sudo apt-get install nodejs -y
+
+# Install npm and serverless
+sudo apt install npm
+sudo npm install -g serverless serverless-azure-functions --save-dev
+
+# Install gcloud CLI
+sudo apt-get install google-cloud-cli
+
+# Install Wrangler CLI
+npm install -g wrangler --save-dev
 
 # For the client to run unattended
 sudo apt-get install --no-install-recommends --assume-yes tmux

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -38,12 +38,6 @@ sudo apt-get install nodejs -y
 sudo apt install npm
 sudo npm install -g serverless serverless-azure-functions --save-dev
 
-# Install gcloud CLI
-sudo apt-get install google-cloud-cli
-
-# Install Wrangler CLI
-npm install -g wrangler --save-dev
-
 # For the client to run unattended
 sudo apt-get install --no-install-recommends --assume-yes tmux
 


### PR DESCRIPTION
Update the scripts in `scripts` folder to install necessary dependencies.

## Changes
- Add `gcr` and `cloudflare` folder for initializing gcloud and wrangler CLI tools
- Update `scripts/setup.sh` to install various dependencies necessary (serverless, azure plugin, gcloud, wrangler, node16, etc.)

@ypwong99 If Azure/Alibaba deployment requires any particular installations and setup, feel free to add to this branch or create another one if we merge this branch first.