### PR TITLE
Update Scheduled Experiments runner on main branch

### DIFF
--- a/.github/workflows/continuous-benchmarking.yml
+++ b/.github/workflows/continuous-benchmarking.yml
@@ -30,7 +30,7 @@ jobs:
 
   clean_up:
     name: Clean-up workspace
-    runs-on: self-hosted
+    runs-on: [self-hosted, aws]
     env:
       working-directory: ./src
     steps:
@@ -42,7 +42,7 @@ jobs:
   build_client:
     name: Build framework
     needs: clean_up
-    runs-on: self-hosted
+    runs-on: [self-hosted, aws]
     env:
       working-directory: ./src
     steps:
@@ -84,7 +84,7 @@ jobs:
   run_function_warm_up:
     name: Run warm function - Warm up
     needs: build_client
-    runs-on: self-hosted
+    runs-on: [self-hosted, aws]
     env:
       working-directory: ./src
     steps:
@@ -96,7 +96,7 @@ jobs:
   run_warm_experiments:
     name: Run warm function tests
     needs: run_function_warm_up
-    runs-on: self-hosted
+    runs-on: [self-hosted, aws]
     env:
       working-directory: ./src
     steps:
@@ -108,7 +108,7 @@ jobs:
   run_cold_experiments:
     name: Run cold function tests
     needs: run_warm_experiments
-    runs-on: self-hosted
+    runs-on: [self-hosted, aws]
     env:
       working-directory: ./src
     steps:
@@ -121,7 +121,7 @@ jobs:
   run_cold_img_size_10_experiments:
     name: Run cold image size test - 10 MB
     needs: run_cold_experiments
-    runs-on: self-hosted
+    runs-on: [self-hosted, aws]
     env:
       working-directory: ./src
     steps:
@@ -133,7 +133,7 @@ jobs:
   run_cold_img_size_60_experiments:
     name: Run cold image size test - 60 MB
     needs: run_cold_img_size_10_experiments
-    runs-on: self-hosted
+    runs-on: [self-hosted, aws]
     env:
       working-directory: ./src
     steps:
@@ -145,7 +145,7 @@ jobs:
   run_cold_img_size_100_experiments:
     name: Run cold image size test - 100 MB
     needs: run_cold_img_size_60_experiments
-    runs-on: self-hosted
+    runs-on: [self-hosted, aws]
     env:
       working-directory: ./src
     steps:
@@ -157,7 +157,7 @@ jobs:
   run_lang_deployment_cold_py_img_experiments:
     name: Run cold python image tests (Python)
     needs: run_cold_img_size_100_experiments
-    runs-on: self-hosted
+    runs-on: [self-hosted, aws]
     env:
       working-directory: ./src
     steps:
@@ -170,7 +170,7 @@ jobs:
   run_lang_deployment_cold_pc_img_experiments:
     name: Run cold python image tests (Go)
     needs: run_lang_deployment_cold_py_img_experiments
-    runs-on: self-hosted
+    runs-on: [self-hosted, aws]
     env:
       working-directory: ./src
     steps:

--- a/.github/workflows/continuous-benchmarking.yml
+++ b/.github/workflows/continuous-benchmarking.yml
@@ -30,7 +30,7 @@ jobs:
 
   clean_up:
     name: Clean-up workspace
-    runs-on: [self-hosted, aws]
+    runs-on: [self-hosted, aws, legacy]
     env:
       working-directory: ./src
     steps:
@@ -42,7 +42,7 @@ jobs:
   build_client:
     name: Build framework
     needs: clean_up
-    runs-on: [self-hosted, aws]
+    runs-on: [self-hosted, aws, legacy]
     env:
       working-directory: ./src
     steps:
@@ -84,7 +84,7 @@ jobs:
   run_function_warm_up:
     name: Run warm function - Warm up
     needs: build_client
-    runs-on: [self-hosted, aws]
+    runs-on: [self-hosted, aws, legacy]
     env:
       working-directory: ./src
     steps:
@@ -96,7 +96,7 @@ jobs:
   run_warm_experiments:
     name: Run warm function tests
     needs: run_function_warm_up
-    runs-on: [self-hosted, aws]
+    runs-on: [self-hosted, aws, legacy]
     env:
       working-directory: ./src
     steps:
@@ -108,7 +108,7 @@ jobs:
   run_cold_experiments:
     name: Run cold function tests
     needs: run_warm_experiments
-    runs-on: [self-hosted, aws]
+    runs-on: [self-hosted, aws, legacy]
     env:
       working-directory: ./src
     steps:
@@ -121,7 +121,7 @@ jobs:
   run_cold_img_size_10_experiments:
     name: Run cold image size test - 10 MB
     needs: run_cold_experiments
-    runs-on: [self-hosted, aws]
+    runs-on: [self-hosted, aws, legacy]
     env:
       working-directory: ./src
     steps:
@@ -133,7 +133,7 @@ jobs:
   run_cold_img_size_60_experiments:
     name: Run cold image size test - 60 MB
     needs: run_cold_img_size_10_experiments
-    runs-on: [self-hosted, aws]
+    runs-on: [self-hosted, aws, legacy]
     env:
       working-directory: ./src
     steps:
@@ -145,7 +145,7 @@ jobs:
   run_cold_img_size_100_experiments:
     name: Run cold image size test - 100 MB
     needs: run_cold_img_size_60_experiments
-    runs-on: [self-hosted, aws]
+    runs-on: [self-hosted, aws, legacy]
     env:
       working-directory: ./src
     steps:
@@ -157,7 +157,7 @@ jobs:
   run_lang_deployment_cold_py_img_experiments:
     name: Run cold python image tests (Python)
     needs: run_cold_img_size_100_experiments
-    runs-on: [self-hosted, aws]
+    runs-on: [self-hosted, aws, legacy]
     env:
       working-directory: ./src
     steps:
@@ -170,7 +170,7 @@ jobs:
   run_lang_deployment_cold_pc_img_experiments:
     name: Run cold python image tests (Go)
     needs: run_lang_deployment_cold_py_img_experiments
-    runs-on: [self-hosted, aws]
+    runs-on: [self-hosted, aws, legacy]
     env:
       working-directory: ./src
     steps:


### PR DESCRIPTION
This PR prevents the current scheduled experiments that are triggered on the `main` branch from taking non-AWS runners as the VM to do benchmarking. This is a short term change to prevent any errors on the scheduled experiments and interference with testing before we eventually update main with scheduled experiments for all providers and their respective VMs.

## Changes
- Add `aws` and `legacy` label in addition to `self-hosted` in `continuous-benchmarking.yml` workflow file