### PR TITLE
independent service for Azure parallel subexperiments

### DIFF
--- a/src/setup/test/serverless-config_test.go
+++ b/src/setup/test/serverless-config_test.go
@@ -91,26 +91,6 @@ func TestAddFunctionConfigAWS(t *testing.T) {
 func TestAddFunctionConfigAzure(t *testing.T) {
 	expected := &setup.Serverless{
 		Functions: map[string]*setup.Function{
-			"test1-2-0": {
-				Name:    "test1-2-0",
-				Handler: "main.main",
-				Runtime: "Python3.8",
-				Package: setup.FunctionPackage{
-					Patterns: []string{"main.py"},
-					Artifact: "",
-				},
-				Events: []setup.Event{
-					{
-						AzureEvent: &setup.AzureEvent{
-							AzureHttpEvent: setup.AzureHttpEvent{
-								AzureHttp:      true,
-								AzureMethods:   []string{"GET"},
-								AzureAuthLevel: "anonymous",
-							},
-						},
-					},
-				},
-			},
 			"test1-2-1": {
 				Name:    "test1-2-1",
 				Handler: "main.main",
@@ -137,11 +117,11 @@ func TestAddFunctionConfigAzure(t *testing.T) {
 	actual := &setup.Serverless{}
 
 	subEx := &setup.SubExperiment{Title: "test1", Parallelism: 2, Runtime: "Python3.8", Handler: "main.main", PackagePattern: "main.py"}
-	actual.AddFunctionConfigAzure(subEx, 2, "")
+	actual.AddFunctionConfigAzure(subEx, 2, 1)
 
 	require.Equal(t, expected, actual)
 
-	require.Equal(t, []string{"test1-2-0", "test1-2-1"}, subEx.Routes)
+	require.Equal(t, []string{"test1-2-1"}, subEx.Routes)
 }
 
 func TestCreateServerlessConfigFile(t *testing.T) {


### PR DESCRIPTION
### Background

I was working on running warm and cold experiments for Azure and noticed unusual results (see attached image), where the median latency for cold experiments was unexpectedly lower than the warm experiments.
![Screenshot 2023-09-26 at 12 02 06](https://github.com/vhive-serverless/STeLLAR/assets/71182438/569d9cab-c47c-4a62-ab85-47018285b99f)

After some research, it looks like cold starts might occur at the function app (group of functions or 'service) level, so we may have to deploy each parallel functions in an independent service.

From https://stackoverflow.com/questions/69661534/are-azure-functions-cold-starts-for-each-client:
> If I have multiple Functions in my app, does each Function has its own cold start or is it one cold start for the entire app?
> Cold start is on Function App level, not on individual Function level.

I could not find this on official Azure documentation though.

### Changes

- `ProvisionFunctionsServerlessAzure` and `AddFunctionConfigAzure` modified to generate separate `serverless.yml` files for each sub-experiment and each parallelism, e.g. `src/setup/deployment/raw-code/serverless/azure/sub-experiment-0/parallelism-0/serverless.yml`