### PR TITLE
Increase burst sizes for scheduled experiments

### DIFF
--- a/continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-aws.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-aws.json
@@ -10,7 +10,7 @@
 	  "Handler": "main.lambda_handler",
 	  "PackageType": "Zip",
 	  "PackagePattern": "main.py",
-      "Bursts": 50,
+      "Bursts": 1000,
       "BurstSizes": [
         1
       ],

--- a/continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-azure.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-azure.json
@@ -9,7 +9,7 @@
       "Handler": "main.main",
       "PackageType": "Zip",
       "PackagePattern": "main.py",
-      "Bursts": 50,
+      "Bursts": 1000,
       "BurstSizes": [
         1
       ],

--- a/continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-cloudflare.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-cloudflare.json
@@ -7,7 +7,7 @@
       "Title": "cold-baseline-cloudflare",
       "Function": "hellopy",
 	  "Handler": "dist/main.js",
-      "Bursts": 50,
+      "Bursts": 1000,
       "BurstSizes": [
         1
       ],

--- a/continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-gcr.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-gcr.json
@@ -9,7 +9,7 @@
 	  "Handler": "Dockerfile",
 	  "PackageType": "Container",
 	  "PackagePattern": "lambda_function.py",
-      "Bursts": 50,
+      "Bursts": 1000,
       "BurstSizes": [
         1
       ],

--- a/continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-aws.json
+++ b/continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-aws.json
@@ -10,7 +10,7 @@
 	  "Handler": "main.lambda_handler",
 	  "PackageType": "Zip",
 	  "PackagePattern": "main.py",
-      "Bursts": 51,
+      "Bursts": 1001,
       "BurstSizes": [
         1
       ],

--- a/continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-azure.json
+++ b/continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-azure.json
@@ -9,11 +9,11 @@
       "Handler": "main.main",
       "PackageType": "Zip",
       "PackagePattern": "main.py",
-      "Bursts": 51,
+      "Bursts": 1001,
       "BurstSizes": [
         1
       ],
-      "IATSeconds": 10,
+      "IATSeconds": 3,
       "DesiredServiceTimes": [
         "0ms"
       ]

--- a/continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-cloudflare.json
+++ b/continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-cloudflare.json
@@ -7,7 +7,7 @@
       "Title": "warm-baseline-cloudflare",
       "Function": "hellopy",
 	  "Handler": "dist/main.js",
-      "Bursts": 51,
+      "Bursts": 1001,
       "BurstSizes": [
         1
       ],

--- a/continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-gcr.json
+++ b/continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-gcr.json
@@ -9,7 +9,7 @@
 	  "Handler": "Dockerfile",
 	  "PackageType": "Container",
 	  "PackagePattern": "lambda_function.py",
-      "Bursts": 51,
+      "Bursts": 1001,
       "BurstSizes": [
         1
       ],


### PR DESCRIPTION
This PR increases the burst size of scheduled experiments to 1000.

## Changes
- Update warm and cold baseline experiment JSON files with new burst size