### PR TITLE
upload `latency-samples` as artifact

### DIFF
--- a/.github/workflows/continuous-benchmarking.yml
+++ b/.github/workflows/continuous-benchmarking.yml
@@ -118,6 +118,11 @@ jobs:
         working-directory: ${{env.working-directory}}
         run: ./stellar -a 356764711652 -o latency-samples -c ../continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-aws.json -db -w
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: aws-warm-latency-samples
+          path: ${{env.working-directory}}/latency-samples
+
   run_warm_experiments_gcr:
     name: Run GCR warm function experiments
     needs: build_client
@@ -161,6 +166,11 @@ jobs:
         working-directory: ${{env.working-directory}}
         run: ./stellar -a 356764711652 -o latency-samples -c ../continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-gcr.json -db -w
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: gcr-warm-latency-samples
+          path: ${{env.working-directory}}/latency-samples
+
   run_warm_experiments_cloudflare:
     name: Run Cloudflare warm function experiments
     needs: build_client
@@ -191,6 +201,11 @@ jobs:
       - name: Cloudflare Warm Function Invocation - Baseline
         working-directory: ${{env.working-directory}}
         run: ./stellar -a 356764711652 -o latency-samples -c ../continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-cloudflare.json -db -w
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: cloudflare-warm-latency-samples
+          path: ${{env.working-directory}}/latency-samples
 
   run_warm_experiments_azure:
     name: Run Azure warm function experiments
@@ -231,6 +246,11 @@ jobs:
       - name: Azure Warm Function Invocation - Baseline
         working-directory: ${{env.working-directory}}
         run: ./stellar -c ../continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-azure.json -db -w
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: azure-warm-latency-samples
+          path: ${{env.working-directory}}/latency-samples
 
   run_cold_experiments_aws:
     name: Run AWS cold function experiments
@@ -279,6 +299,11 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
         run: ./stellar -a 356764711652 -o latency-samples -c ../continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-aws.json -db
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: aws-cold-latency-samples
+          path: ${{env.working-directory}}/latency-samples
+
   run_cold_experiments_gcr:
     name: Run GCR cold function experiments
     needs: run_warm_experiments_gcr
@@ -322,6 +347,11 @@ jobs:
         working-directory: ${{env.working-directory}}
         run: ./stellar -a 356764711652 -o latency-samples -c ../continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-gcr.json -db
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: gcr-cold-latency-samples
+          path: ${{env.working-directory}}/latency-samples
+
   run_cold_experiments_cloudflare:
     name: Run Cloudflare cold function experiments
     needs: run_warm_experiments_cloudflare
@@ -352,6 +382,11 @@ jobs:
       - name: Cloudflare Cold Function Invocation - Baseline
         working-directory: ${{env.working-directory}}
         run: ./stellar -a 356764711652 -o latency-samples -c ../continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-cloudflare.json -db
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: gcr-cold-latency-samples
+          path: ${{env.working-directory}}/latency-samples
 
   run_cold_experiments_azure:
     name: Run Azure cold function experiments
@@ -392,3 +427,8 @@ jobs:
       - name: Azure Cold Function Invocation - Baseline
         working-directory: ${{env.working-directory}}
         run: ./stellar -c ../continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-azure.json -db -l debug
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: azure-cold-latency-samples
+          path: ${{env.working-directory}}/latency-samples


### PR DESCRIPTION
This PR changes the `continuous-benchmarking` workflow to upload the `latency-samples` directory generated by experiment runs, as an artifact, so that CDF charts can be downloaded and checked.