### PR TITLE
fix: wrong ordering in `Endpoints` slice within `SubExperiment` struct

### DIFF
--- a/src/setup/run.go
+++ b/src/setup/run.go
@@ -168,6 +168,8 @@ func deploySubExperimentParallelismInBatches(config *Configuration, serverlessDi
 
 	numberOfBatches := int(math.Ceil(float64(subExperiment.Parallelism) / float64(functionsPerBatch)))
 
+	endpoints := make(map[int]EndpointInfo)
+
 	for batchNumber := 0; batchNumber < numberOfBatches; batchNumber++ {
 		mu := sync.Mutex{}
 		wg := sync.WaitGroup{}
@@ -197,11 +199,14 @@ func deploySubExperimentParallelismInBatches(config *Configuration, serverlessDi
 				endpointID := GetAzureEndpointID(slsDeployMessage)
 				mu.Lock()
 				defer mu.Unlock()
-				config.SubExperiments[subExperimentIndex].Endpoints = append(config.SubExperiments[subExperimentIndex].Endpoints, EndpointInfo{ID: endpointID})
+				endpoints[parallelism] = EndpointInfo{ID: endpointID}
 			}(parallelism)
-
 		}
 		wg.Wait()
+	}
+
+	for i := 0; i < subExperiment.Parallelism; i++ {
+		config.SubExperiments[subExperimentIndex].Endpoints = append(config.SubExperiments[subExperimentIndex].Endpoints, endpoints[i])
 	}
 }
 


### PR DESCRIPTION
From the latest scheduled experiment run, I observed that there were issues with the bursts being sent to the wrong URL and obtaining a HTTP 404 status code.
I found that the issue was caused by a wrong ordering within the `Endpoints` slice in the `SubExperiment` struct. For example, when a batch of 3 goroutines are started to deploy 3 Azure services (`subex0-para0`, `subex0-para1`, `subex0-para2`), the `Endpoints` slice may end up as `subex0-para2`, `subex0-para0`, `subex0-para1` instead.
This PR is a bug fix to the issue above.