### PR TITLE
fix: wrong order of `Routes` slice within `SubExperiment` struct

### DIFF
--- a/src/setup/run.go
+++ b/src/setup/run.go
@@ -169,6 +169,7 @@ func deploySubExperimentParallelismInBatches(config *Configuration, serverlessDi
 	numberOfBatches := int(math.Ceil(float64(subExperiment.Parallelism) / float64(functionsPerBatch)))
 
 	endpoints := make(map[int]EndpointInfo)
+	routes := make(map[int]string)
 
 	for batchNumber := 0; batchNumber < numberOfBatches; batchNumber++ {
 		mu := sync.Mutex{}
@@ -190,7 +191,8 @@ func deploySubExperimentParallelismInBatches(config *Configuration, serverlessDi
 				slsConfig := &Serverless{}
 				slsConfig.CreateHeaderConfig(config, fmt.Sprintf("%s-subex%d-para%d", randomExperimentTag, subExperimentIndex, parallelism))
 				slsConfig.addPlugin("serverless-azure-functions")
-				slsConfig.AddFunctionConfigAzure(&config.SubExperiments[subExperimentIndex], subExperimentIndex, parallelism)
+				name := createName(&subExperiment, subExperimentIndex, parallelism)
+				slsConfig.AddFunctionConfigAzure(&config.SubExperiments[subExperimentIndex], subExperimentIndex, name)
 				slsConfig.CreateServerlessConfigFile(fmt.Sprintf("%s/serverless.yml", deploymentDir))
 
 				log.Infof("Starting functions deployment. Deploying %d functions to %s.", len(slsConfig.Functions), config.Provider)
@@ -200,6 +202,7 @@ func deploySubExperimentParallelismInBatches(config *Configuration, serverlessDi
 				mu.Lock()
 				defer mu.Unlock()
 				endpoints[parallelism] = EndpointInfo{ID: endpointID}
+				routes[parallelism] = name
 			}(parallelism)
 		}
 		wg.Wait()
@@ -207,6 +210,7 @@ func deploySubExperimentParallelismInBatches(config *Configuration, serverlessDi
 
 	for i := 0; i < subExperiment.Parallelism; i++ {
 		config.SubExperiments[subExperimentIndex].Endpoints = append(config.SubExperiments[subExperimentIndex].Endpoints, endpoints[i])
+		config.SubExperiments[subExperimentIndex].Routes = append(config.SubExperiments[subExperimentIndex].Routes, routes[i])
 	}
 }
 

--- a/src/setup/serverless-config.go
+++ b/src/setup/serverless-config.go
@@ -193,7 +193,7 @@ func (s *Serverless) AddFunctionConfigAWS(subex *SubExperiment, index int, artif
 }
 
 // AddFunctionConfigAzure Adds a function to the service. If parallelism = n, then it defines n functions. Also deploys all producer-consumer subfunctions.
-func (s *Serverless) AddFunctionConfigAzure(subex *SubExperiment, index int, parallelism int) {
+func (s *Serverless) AddFunctionConfigAzure(subex *SubExperiment, index int, name string) {
 	log.Infof("Adding function config of Subexperiment %s, index %d", subex.Function, index)
 
 	if s.Functions == nil {
@@ -202,7 +202,6 @@ func (s *Serverless) AddFunctionConfigAzure(subex *SubExperiment, index int, par
 
 	handler := subex.Handler
 	runtime := subex.Runtime
-	name := createName(subex, index, parallelism)
 	events := []Event{
 		{
 			AzureEvent: &AzureEvent{
@@ -218,7 +217,6 @@ func (s *Serverless) AddFunctionConfigAzure(subex *SubExperiment, index int, par
 	function := &Function{Handler: handler, Runtime: runtime, Name: name, Events: events}
 	function.AddPackagePattern(subex.PackagePattern)
 	s.Functions[name] = function
-	subex.AddRoute(name)
 }
 
 // AddFunctionConfigAlibaba Adds a function to the service. If parallelism = n, then it defines n functions. Also deploys all producer-consumer subfunctions.

--- a/src/setup/test/serverless-config_test.go
+++ b/src/setup/test/serverless-config_test.go
@@ -117,11 +117,9 @@ func TestAddFunctionConfigAzure(t *testing.T) {
 	actual := &setup.Serverless{}
 
 	subEx := &setup.SubExperiment{Title: "test1", Parallelism: 2, Runtime: "Python3.8", Handler: "main.main", PackagePattern: "main.py"}
-	actual.AddFunctionConfigAzure(subEx, 2, 1)
+	actual.AddFunctionConfigAzure(subEx, 2, "test1-2-1")
 
 	require.Equal(t, expected, actual)
-
-	require.Equal(t, []string{"test1-2-1"}, subEx.Routes)
 }
 
 func TestCreateServerlessConfigFile(t *testing.T) {


### PR DESCRIPTION
This PR is a follow-up to the issue mentioned in #320.