### PR TITLE
Fix Cloudflare cold baseline experiment artifact upload

### DIFF
--- a/.github/workflows/continuous-benchmarking.yml
+++ b/.github/workflows/continuous-benchmarking.yml
@@ -385,7 +385,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: gcr-cold-latency-samples
+          name: cloudflare-cold-latency-samples
           path: ${{env.working-directory}}/latency-samples
 
   run_cold_experiments_azure:


### PR DESCRIPTION
Cloudflare's cold baseline artifact in scheduled experiments is mistakenly named as `gcr-cold-latency-samples`, which overrides GCR's artifact. This PR remedies the issue.

## Changes
- Rename Cloudflare cold baseline artifact to `cloudflare-cold-latency-samples` in `continuous-benchmarking.yml`