### PR TITLE
increase job timeout for `continuous-benchmarking` workflow

### DIFF
--- a/.github/workflows/continuous-benchmarking.yml
+++ b/.github/workflows/continuous-benchmarking.yml
@@ -392,6 +392,7 @@ jobs:
     name: Run Azure cold function experiments
     needs: run_warm_experiments_azure
     runs-on: [ self-hosted, azure ]
+    timeout-minutes: 540
     env:
       working-directory: src
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
This PR increases the job timeout for Azure baseline cold experiments in the `continuous-benchmarking` workflow from the default of 6h to 9h. A previous [job](https://github.com/vhive-serverless/STeLLAR/actions/runs/6502230498/job/17669186013) could not be completed as it was cancelled by the runner after exceeding the default limit.