### PR TITLE
Discard non-200 status response benchmark samples

### DIFF
--- a/src/benchmarking/networking/benchhttp/execute_test.go
+++ b/src/benchmarking/networking/benchhttp/execute_test.go
@@ -33,7 +33,7 @@ func TestExecuteExternalHTTPRequest(t *testing.T) {
 	randomAssignedIncrement := int64(1482911482)
 	req := CreateRequest("www.google.com", randomPayloadLength, setup.EndpointInfo{}, randomAssignedIncrement, false, "route1")
 
-	respBytes, reqSentTime, reqReceivedTime := ExecuteRequest(*req)
+	_, respBytes, reqSentTime, reqReceivedTime := ExecuteRequest(*req)
 	require.Equal(t, true, respBytes != nil)
 	require.Equal(t, true, reqReceivedTime.Sub(reqSentTime) > 0)
 }


### PR DESCRIPTION
This PR resolves #326. Requests that respond a non-200 status response will no longer be included in the latency samples recorded. 

If erroneous responses exceed 10% of the total requests for a subexperiment, the experiment will terminate. If multiple burst sizes are specified, the threshold is 10% of `minimumBurstSize * totalBursts`.

## Changes
- Update `ExecuteRequest` to return `ok` boolean
- Update `benchmarking/run.go` to not write latencies for non-200 status code responses
- Update `benchmarking/run.go` to abort if error threshold exceeds 10%