### PR TITLE
Update client build step runner to Github's runner

### DIFF
--- a/.github/workflows/continuous-benchmarking.yml
+++ b/.github/workflows/continuous-benchmarking.yml
@@ -44,7 +44,7 @@ jobs:
   build_client:
     name: Build framework
     needs: clean_up
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     env:
       working-directory: ./src
     steps:


### PR DESCRIPTION
This PR updates the runner in "Build framework" step of the scheduled experiments from a self-hosted runner to Github's runners; building the framework does not need to be on our self-hosted runners since no benchmarking is being done. 

This change is a precaution in case this step generates artifacts that hog space on our self-hosted runners.

## Changes
- Update Build framework step in `continuous-benchmarking.yml`