### PR TITLE
Add random prefix to function name (AWS, GCR, Cloudflare)

### DIFF
--- a/src/setup/integration-test/serverless-config_test.go
+++ b/src/setup/integration-test/serverless-config_test.go
@@ -40,9 +40,9 @@ func TestDeployAndRemoveServiceGCR(t *testing.T) {
 		Parallelism: 1,
 	}
 
-	s.DeployGCRContainerService(subex, 0, "docker.io/kkmin/hellopy", "../deployment/raw-code/serverless/gcr/hellopy/", "us-west1")
-	deleteMsg := setup.RemoveGCRSingleService("hellopytest-0-0")
-	assert.True(strings.Contains(deleteMsg, "Deleted service [hellopytest-0-0]"))
+	s.DeployGCRContainerService(subex, 0, "abc12", "docker.io/kkmin/hellopy", "../deployment/raw-code/serverless/gcr/hellopy/", "us-west1")
+	deleteMsg := setup.RemoveGCRSingleService("abc12-hellopytest-0-0")
+	assert.True(strings.Contains(deleteMsg, "Deleted service [abc12-hellopytest-0-0]"))
 }
 
 func TestDeployAndRemoveServiceAzure(t *testing.T) {
@@ -67,8 +67,8 @@ func TestDeployAndRemoveServiceCloudflare(t *testing.T) {
 		Parallelism: 1,
 	}
 
-	setup.DeployCloudflareWorkers(subex, 0, "../deployment/raw-code/serverless/cloudflare")
-	msgRemove := setup.RemoveCloudflareSingleWorker("cloudflaretest-0-0")
+	setup.DeployCloudflareWorkers(subex, 0, "abc12", "../deployment/raw-code/serverless/cloudflare")
+	msgRemove := setup.RemoveCloudflareSingleWorker("abc12-cloudflaretest-0-0")
 
 	assert.True(strings.Contains(msgRemove, "Successfully deleted"))
 }

--- a/src/setup/run.go
+++ b/src/setup/run.go
@@ -122,7 +122,8 @@ func ProvisionFunctionsServerlessAWS(config *Configuration, serverlessDirPath st
 
 		// TODO: build the functions (Java and Golang)
 		artifactPathRelativeToServerlessConfigFile := builder.BuildFunction(config.Provider, subExperiment.Function, subExperiment.Runtime)
-		slsConfig.AddFunctionConfigAWS(&config.SubExperiments[index], index, artifactPathRelativeToServerlessConfigFile)
+		randomTag := util.GenerateRandLowercaseLetters(5)
+		slsConfig.AddFunctionConfigAWS(&config.SubExperiments[index], index, randomTag, artifactPathRelativeToServerlessConfigFile)
 
 		// generate filler files and zip used as Serverless artifacts
 		packaging.GenerateServerlessZIPArtifacts(subExperiment.ID, config.Provider, subExperiment.Runtime, subExperiment.Function, subExperiment.FunctionImageSizeMB)
@@ -222,7 +223,8 @@ func ProvisionFunctionsGCR(config *Configuration, serverlessDirPath string) {
 		switch subExperiment.PackageType {
 		case "Container":
 			imageLink := packaging.SetupContainerImageDeployment(subExperiment.Function, config.Provider)
-			slsConfig.DeployGCRContainerService(&config.SubExperiments[index], index, imageLink, serverlessDirPath, slsConfig.Provider.Region)
+			randomTag := util.GenerateRandLowercaseLetters(5)
+			slsConfig.DeployGCRContainerService(&config.SubExperiments[index], index, randomTag, imageLink, serverlessDirPath, slsConfig.Provider.Region)
 		default:
 			log.Fatalf("Package type %s is not supported", subExperiment.PackageType)
 		}
@@ -231,7 +233,8 @@ func ProvisionFunctionsGCR(config *Configuration, serverlessDirPath string) {
 
 func ProvisionFunctionsCloudflare(config *Configuration, serverlessDirPath string) {
 	for index := range config.SubExperiments {
-		DeployCloudflareWorkers(&config.SubExperiments[index], index, serverlessDirPath)
+		randomTag := util.GenerateRandLowercaseLetters(5)
+		DeployCloudflareWorkers(&config.SubExperiments[index], index, randomTag, serverlessDirPath)
 	}
 }
 

--- a/src/setup/serverless-config.go
+++ b/src/setup/serverless-config.go
@@ -96,6 +96,7 @@ type AlibabaHttpEvent struct {
 }
 
 var nonAlphanumericRegex *regexp.Regexp = regexp.MustCompile(`[^a-zA-Z0-9 ]+`)
+var providerFunctionNames map[string]([]string) = make(map[string]([]string))
 
 const (
 	AWS_DEFAULT_REGION         = "us-west-1"
@@ -158,7 +159,7 @@ func (f *Function) AddPackagePattern(pattern string) {
 }
 
 // AddFunctionConfigAWS Adds a function to the service. If parallelism = n, then it defines n functions. Also deploys all producer-consumer subfunctions.
-func (s *Serverless) AddFunctionConfigAWS(subex *SubExperiment, index int, artifactPath string) {
+func (s *Serverless) AddFunctionConfigAWS(subex *SubExperiment, index int, randomTag string, artifactPath string) {
 	log.Infof("Adding function config of Subexperiment %s, index %d", subex.Function, index)
 	if s.Functions == nil {
 		s.Functions = make(map[string]*Function)
@@ -166,7 +167,7 @@ func (s *Serverless) AddFunctionConfigAWS(subex *SubExperiment, index int, artif
 	for i := 0; i < subex.Parallelism; i++ {
 		handler := subex.Handler
 		runtime := subex.Runtime
-		name := createName(subex, index, i)
+		name := fmt.Sprintf("%s-%s", randomTag, createName(subex, index, i))
 		events := []Event{
 			{
 				AWSEvent: &AWSEvent{
@@ -353,12 +354,9 @@ func removeSubExperimentParallelismInBatches(path string, subExperimentIndex int
 // RemoveGCRAllServices removes all GCR services defined in the Subexperiment array
 func RemoveGCRAllServices(subExperiments []SubExperiment) []string {
 	var deleteServiceMessages []string
-	for index, subex := range subExperiments {
-		for i := 0; i < subex.Parallelism; i++ {
-			service := createName(&subex, index, i)
-			deleteMsg := RemoveGCRSingleService(service)
-			deleteServiceMessages = append(deleteServiceMessages, deleteMsg)
-		}
+	for _, functionName := range providerFunctionNames["gcr"] {
+		deleteMsg := RemoveGCRSingleService(functionName)
+		deleteServiceMessages = append(deleteServiceMessages, deleteMsg)
 	}
 	return deleteServiceMessages
 }
@@ -375,12 +373,9 @@ func RemoveGCRSingleService(service string) string {
 func RemoveCloudflareAllWorkers(subExperiments []SubExperiment) []string {
 	log.Infof("Removing Cloudflare Workers...")
 	var removeServiceMessages []string
-	for index, subex := range subExperiments {
-		for i := 0; i < subex.Parallelism; i++ {
-			workerName := createName(&subex, index, i)
-			removeMessage := RemoveCloudflareSingleWorker(workerName)
-			removeServiceMessages = append(removeServiceMessages, removeMessage)
-		}
+	for _, functionName := range providerFunctionNames["cloudflare"] {
+		removeMessage := RemoveCloudflareSingleWorker(functionName)
+		removeServiceMessages = append(removeServiceMessages, removeMessage)
 	}
 	return removeServiceMessages
 }
@@ -421,10 +416,11 @@ func DeployService(path string) string {
 }
 
 // DeployGCRContainerService deploys a container service to cloud provider
-func (s *Serverless) DeployGCRContainerService(subex *SubExperiment, index int, imageLink string, path string, region string) {
+func (s *Serverless) DeployGCRContainerService(subex *SubExperiment, index int, randomTag string, imageLink string, path string, region string) {
 	log.Infof("Deploying container service(s) to GCR...")
 	for i := 0; i < subex.Parallelism; i++ {
-		name := createName(subex, index, i)
+		name := fmt.Sprintf("%s-%s", randomTag, createName(subex, index, i))
+		providerFunctionNames["gcr"] = append(providerFunctionNames["gcr"], name) // Used for function removal
 
 		gcrDeployCommand := exec.Command("gcloud", "run", "deploy", name, "--image", imageLink, "--allow-unauthenticated", "--region", region)
 		deployMessage := util.RunCommandAndLog(gcrDeployCommand)
@@ -433,10 +429,11 @@ func (s *Serverless) DeployGCRContainerService(subex *SubExperiment, index int, 
 	}
 }
 
-func DeployCloudflareWorkers(subex *SubExperiment, index int, path string) {
+func DeployCloudflareWorkers(subex *SubExperiment, index int, randomTag string, path string) {
 	log.Infof("Deploying Cloudflare Workers...")
 	for i := 0; i < subex.Parallelism; i++ {
-		name := createName(subex, index, i)
+		name := fmt.Sprintf("%s-%s", randomTag, createName(subex, index, i))
+		providerFunctionNames["cloudflare"] = append(providerFunctionNames["cloudflare"], name) // Used for function removal
 
 		cloudFlareDeployCommand := exec.Command("wrangler", "deploy", fmt.Sprintf("%s/%s/%s", path, subex.Function, subex.Handler), "--name", name, "--compatibility-date", time.Now().Format("2006-01-02"))
 		deployMessage := util.RunCommandAndLog(cloudFlareDeployCommand)

--- a/src/setup/test/serverless-config_test.go
+++ b/src/setup/test/serverless-config_test.go
@@ -37,8 +37,8 @@ func TestAddFunctionConfigAWS(t *testing.T) {
 	expected := &setup.Serverless{
 		Package: setup.Package{Individually: true},
 		Functions: map[string]*setup.Function{
-			"test1-2-0": {
-				Name:    "test1-2-0",
+			"abc12-test1-2-0": {
+				Name:    "abc12-test1-2-0",
 				Handler: "main.lambda_handler",
 				Runtime: "Python3.8",
 				Package: setup.FunctionPackage{
@@ -49,15 +49,15 @@ func TestAddFunctionConfigAWS(t *testing.T) {
 					{
 						AWSEvent: &setup.AWSEvent{
 							AWSHttpEvent: setup.AWSHttpEvent{
-								Path:   "/test1-2-0",
+								Path:   "/abc12-test1-2-0",
 								Method: "GET",
 							},
 						},
 					},
 				},
 			},
-			"test1-2-1": {
-				Name:    "test1-2-1",
+			"abc12-test1-2-1": {
+				Name:    "abc12-test1-2-1",
 				Handler: "main.lambda_handler",
 				Runtime: "Python3.8",
 				Package: setup.FunctionPackage{
@@ -68,7 +68,7 @@ func TestAddFunctionConfigAWS(t *testing.T) {
 					{
 						AWSEvent: &setup.AWSEvent{
 							AWSHttpEvent: setup.AWSHttpEvent{
-								Path:   "/test1-2-1",
+								Path:   "/abc12-test1-2-1",
 								Method: "GET",
 							},
 						},
@@ -81,11 +81,11 @@ func TestAddFunctionConfigAWS(t *testing.T) {
 	actual := &setup.Serverless{Package: setup.Package{Individually: true}}
 
 	subEx := &setup.SubExperiment{Title: "test1", Parallelism: 2, Runtime: "Python3.8", Handler: "main.lambda_handler", PackagePattern: "main.py"}
-	actual.AddFunctionConfigAWS(subEx, 2, "")
+	actual.AddFunctionConfigAWS(subEx, 2, "abc12", "")
 
 	require.Equal(t, expected, actual)
 
-	require.Equal(t, []string{"test1-2-0", "test1-2-1"}, subEx.Routes)
+	require.Equal(t, []string{"abc12-test1-2-0", "abc12-test1-2-1"}, subEx.Routes)
 }
 
 func TestAddFunctionConfigAzure(t *testing.T) {


### PR DESCRIPTION
This PR is adds a random prefix to the function name for AWS, GCR, Cloudflare (Similar to #317's implementation for Azure) to minimize deployment conflicts, especially when there are several Github workflows running in parallel.

## Changes
- Add `randomTag` prefix to all deployed function names
- Add `providerFunctionNames` map that tracks the deployed function names for each provider. This is necessary for GCR and Cloudflare, as previously their removal process relies on deterministic function names (based on index and parallelism). Now they rely on this structure for tracking deployed function names to remove.
- Update unit tests and integration tests