### PR TITLE
fix: Prevent fatal error on failed HTTP requests

### DIFF
--- a/.github/workflows/feature-serverless-framework-deployment.yml
+++ b/.github/workflows/feature-serverless-framework-deployment.yml
@@ -451,10 +451,6 @@ jobs:
           cp -R ./src/setup/deployment/raw-code/functions setup/deployment/raw-code/functions
           mkdir -p './src/latency-samples'
 
-      - name: Cloudflare end-to-end test for Node
-        working-directory: ${{env.working-directory}}
-        run: ./main --o latency-samples --c ../experiments/tests/cloudflare/hellonode.json --s true
-
       - name: Cloudflare end-to-end test for Python
         working-directory: ${{env.working-directory}}
         run: ./main --o latency-samples --c ../experiments/tests/cloudflare/hellopy.json --s true


### PR DESCRIPTION
This PR extends #328 to HTTP requests that fail to send to the endpoint, which currently results in a fatal error that disrupts the workflow. The same logic is applied to these failed requests and they are counted under the total number of erroneous requests.

## Changes
- Update `sendTimedRequest` to return the error instead of failing fatally when HTTP requests fail to send