### PR TITLE
Update Burst Size assignment to be cyclical

### DIFF
--- a/src/benchmarking/run.go
+++ b/src/benchmarking/run.go
@@ -65,7 +65,7 @@ func runSubExperiment(experiment setup.SubExperiment, burstDeltas []time.Duratio
 		for gatewayID := 0; gatewayID < len(experiment.Endpoints) && burstID < experiment.Bursts; gatewayID++ {
 			// Every refresh period, we cycle through burst sizes if they're dynamic i.e. more than 1 element
 			incrementLimit := experiment.BusySpinIncrements[util.IntegerMin(deltaIndex, len(experiment.BusySpinIncrements)-1)]
-			burstSize := experiment.BurstSizes[util.IntegerMin(deltaIndex, len(experiment.BurstSizes)-1)]
+			burstSize := experiment.BurstSizes[deltaIndex%len(experiment.BurstSizes)]
 			log.Infof("%d", len(experiment.Routes))
 			sendBurst(provider, experiment, burstID, burstSize, experiment.Endpoints[gatewayID], incrementLimit, latenciesWriter, dataTransferWriter, experiment.Routes[gatewayID], &errorCount)
 			errs := errorCount.Read()


### PR DESCRIPTION
Currently, if the length of the specified `BurstSizes` array in the experiment JSON file is smaller than the number of bursts, all bursts from burst number `len(BurstSizes)` and beyond will have a burstSize value of the last burst size in the BurstSizes array.

This PR updates this behaviour to instead cycle through the BurstSizes array in a cyclical manner (i.e. wrap back to `BurstSizes[0]` if BurstSizes are exhausted) rather than always using the last burst size.

## Changes
- Update burst size assignment for `runSubExperiment` function in `src/benchmarking/run.go`