### PR TITLE
update Node installation commands

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
-sudo add-apt-repository ppa:longsleep/golang-backports
-sudo add-apt-repository ppa:linuxuprising/java
-sudo add-apt-repository ppa:cwchien/gradle
-sudo apt-get install apt-transport-https ca-certificates gnupg curl sudo
+
+sudo add-apt-repository --yes ppa:longsleep/golang-backports
+sudo add-apt-repository --yes ppa:linuxuprising/java
+sudo add-apt-repository --yes ppa:cwchien/gradle
+sudo apt-get update
+sudo apt-get install --yes apt-transport-https ca-certificates gnupg curl sudo
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-sudo apt-get update
 
 # Set up Docker Registry
 sudo install -m 0755 -d /etc/apt/keyrings
@@ -22,21 +21,24 @@ sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # Install Golang
-sudo apt install golang
+sudo apt install --yes golang
 
 # Install OpenJDK 11
-sudo apt-get install openjdk-11-jdk
+sudo apt-get install --yes openjdk-11-jdk
 
 # Install Gradle
-sudo apt install gradle
+sudo apt install --yes gradle
 
-# Install Node
+# Install Node using Nodesource https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 NODE_MAJOR=16
-sudo apt-get install nodejs -y
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+sudo apt-get update
+sudo apt-get install --yes nodejs
 
-# Install npm and serverless
-sudo apt install npm
-sudo npm install -g serverless serverless-azure-functions --save-dev
+# Install Serverless and related plugins
+sudo npm install -g serverless serverless-azure-functions functions-have-names
 
 # For the client to run unattended
 sudo apt-get install --no-install-recommends --assume-yes tmux

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,7 +4,7 @@ sudo add-apt-repository --yes ppa:longsleep/golang-backports
 sudo add-apt-repository --yes ppa:linuxuprising/java
 sudo add-apt-repository --yes ppa:cwchien/gradle
 sudo apt-get update
-sudo apt-get install --yes apt-transport-https ca-certificates gnupg curl sudo
+sudo apt-get install --yes apt-transport-https ca-certificates curl gnupg sudo zip
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 


### PR DESCRIPTION
This PR updates the Node installation commands in the setup script to follow the [instructions](https://github.com/nodesource/distributions#installation-instructions) by Nodesource.

Previously the `echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list` command appears to have been executed before `NODE_MAJOR` was set.

This PR also adds `--yes` flags to other commands, so that the setup script can run without further user input.

The updated setup script has been tested on an Azure Standard B1s VM.