### PR TITLE
Add Node and Ruby runtime raw-code for AWS

### DIFF
--- a/experiments/tests/aws/hellonode.json
+++ b/experiments/tests/aws/hellonode.json
@@ -1,0 +1,17 @@
+{
+  "Sequential": false,
+  "Provider": "aws",
+  "Runtime": "nodejs18.x",
+  "SubExperiments": [
+    {
+      "Title": "hellonode",
+      "Function": "hellonode",
+      "Handler": "index.handler",
+      "PackageType": "Zip",
+      "PackagePattern": "index.js",
+      "Bursts": 2,
+      "BurstSizes": [2],
+      "DesiredServiceTimes": ["0ms"]
+    }
+  ]
+}

--- a/experiments/tests/aws/helloruby.json
+++ b/experiments/tests/aws/helloruby.json
@@ -1,0 +1,17 @@
+{
+  "Sequential": false,
+  "Provider": "aws",
+  "Runtime": "ruby3.2",
+  "SubExperiments": [
+    {
+      "Title": "helloruby",
+      "Function": "helloruby",
+      "Handler": "function.handler",
+      "PackageType": "Zip",
+      "PackagePattern": "function.rb",
+      "Bursts": 2,
+      "BurstSizes": [2],
+      "DesiredServiceTimes": ["0ms"]
+    }
+  ]
+}

--- a/src/setup/building/builder.go
+++ b/src/setup/building/builder.go
@@ -40,6 +40,8 @@ func (b *Builder) BuildFunction(provider string, functionName string, runtime st
 		buildGolang(functionName, functionDir, artifactDir)
 	case "nodejs18.x":
 		copyNodeJSFile(functionName, functionDir, artifactDir)
+	case "ruby3.2":
+		copyRubyFile(functionName, functionDir, artifactDir)
 	case "python3.8":
 		fallthrough
 	case "python3.9":
@@ -83,6 +85,14 @@ func copyNodeJSFile(functioName string, functionDir string, artifactDir string) 
 	log.Infof("Copying Node source code from the %s directory", functionDir)
 	functionPath := fmt.Sprintf("%s/index.js", functionDir)
 	artifactPath := fmt.Sprintf("%s/index.js", artifactDir)
+	util.RunCommandAndLog(exec.Command("cp", functionPath, artifactPath))
+	return artifactPath
+}
+
+func copyRubyFile(functionName string, functionDir string, artifactDir string) string {
+	log.Infof("Copying Ruby source code from the %s directory", functionDir)
+	functionPath := fmt.Sprintf("%s/function.rb", functionDir)
+	artifactPath := fmt.Sprintf("%s/function.rb", artifactDir)
 	util.RunCommandAndLog(exec.Command("cp", functionPath, artifactPath))
 	return artifactPath
 }

--- a/src/setup/building/builder.go
+++ b/src/setup/building/builder.go
@@ -38,6 +38,8 @@ func (b *Builder) BuildFunction(provider string, functionName string, runtime st
 		buildJava(functionName, functionDir, artifactDir)
 	case "go1.x":
 		buildGolang(functionName, functionDir, artifactDir)
+	case "nodejs18.x":
+		copyNodeJSFile(functionName, functionDir, artifactDir)
 	case "python3.8":
 		fallthrough
 	case "python3.9":
@@ -72,6 +74,15 @@ func copyPythonFile(functionName string, functionDir string, artifactDir string)
 	log.Infof("Copying Python source code from the %s directory", functionDir)
 	functionPath := fmt.Sprintf("%s/main.py", functionDir)
 	artifactPath := fmt.Sprintf("%s/main.py", artifactDir)
+	util.RunCommandAndLog(exec.Command("cp", functionPath, artifactPath))
+	return artifactPath
+}
+
+// copyNodeJSFile copies the main NodeJS file into the artifacts directory
+func copyNodeJSFile(functioName string, functionDir string, artifactDir string) string {
+	log.Infof("Copying Node source code from the %s directory", functionDir)
+	functionPath := fmt.Sprintf("%s/index.js", functionDir)
+	artifactPath := fmt.Sprintf("%s/index.js", artifactDir)
 	util.RunCommandAndLog(exec.Command("cp", functionPath, artifactPath))
 	return artifactPath
 }

--- a/src/setup/deployment/packaging/test/zip_test.go
+++ b/src/setup/deployment/packaging/test/zip_test.go
@@ -72,6 +72,17 @@ func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsJava() {
 	assert.InDelta(s.T(), 50, util.BytesToMB(fileInfo.Size()), 0.1)
 }
 
+func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsNode() {
+	b := &building.Builder{}
+	b.BuildFunction("aws", "hellonode", "nodejs18.x")
+	packaging.GenerateServerlessZIPArtifacts(2, "aws", "nodejs18.x", "hellonode", 50)
+	fileInfo, err := os.Stat("setup/deployment/raw-code/serverless/aws/artifacts/hellonode/hellonode.zip")
+	if err != nil {
+		assert.Fail(s.T(), "Could not obtain file info of ZIP artifact")
+	}
+	assert.InDelta(s.T(), 50, util.BytesToMB(fileInfo.Size()), 0.1)
+}
+
 func TestZipTestSuite(t *testing.T) {
 	suite.Run(t, new(ZipTestSuite))
 }

--- a/src/setup/deployment/packaging/test/zip_test.go
+++ b/src/setup/deployment/packaging/test/zip_test.go
@@ -83,6 +83,17 @@ func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsNode() {
 	assert.InDelta(s.T(), 50, util.BytesToMB(fileInfo.Size()), 0.1)
 }
 
+func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsRuby() {
+	b := &building.Builder{}
+	b.BuildFunction("aws", "helloruby", "ruby3.2")
+	packaging.GenerateServerlessZIPArtifacts(2, "aws", "ruby3.2", "helloruby", 50)
+	fileInfo, err := os.Stat("setup/deployment/raw-code/serverless/aws/artifacts/helloruby/helloruby.zip")
+	if err != nil {
+		assert.Fail(s.T(), "Could not obtain file info of ZIP artifact")
+	}
+	assert.InDelta(s.T(), 50, util.BytesToMB(fileInfo.Size()), 0.1)
+}
+
 func TestZipTestSuite(t *testing.T) {
 	suite.Run(t, new(ZipTestSuite))
 }

--- a/src/setup/deployment/packaging/zip.go
+++ b/src/setup/deployment/packaging/zip.go
@@ -109,18 +109,21 @@ func GenerateServerlessZIPArtifacts(experimentID int, provider string, runtime s
 		fallthrough
 	case "nodejs18.x":
 		fallthrough
+	case "ruby3.2":
+		fallthrough
 	case "go1.x":
-		generateServerlessZIPArtifactsPythonGolangNode(experimentID, provider, runtime, functionName, functionImageSizeMB)
+		generateServerlessZIPArtifactsGeneral(experimentID, provider, runtime, functionName, functionImageSizeMB)
 	case "java11":
 		generateServerlessZIPArtifactsJava(experimentID, provider, runtime, functionName, functionImageSizeMB)
 	}
 }
 
-func generateServerlessZIPArtifactsPythonGolangNode(experimentID int, provider string, runtime string, functionName string, functionImageSizeMB float64) {
+func generateServerlessZIPArtifactsGeneral(experimentID int, provider string, runtime string, functionName string, functionImageSizeMB float64) {
 	defaultBinaryName := map[string]string{
 		"python3.9":  "main.py",
 		"go1.x":      "main",
 		"nodejs18.x": "index.js",
+		"ruby3.2":    "function.rb",
 	}
 	binaryPath := fmt.Sprintf("setup/deployment/raw-code/serverless/%s/artifacts/%s/%s", provider, functionName, defaultBinaryName[runtime])
 

--- a/src/setup/deployment/packaging/zip.go
+++ b/src/setup/deployment/packaging/zip.go
@@ -107,17 +107,20 @@ func GenerateServerlessZIPArtifacts(experimentID int, provider string, runtime s
 	switch runtime {
 	case "python3.9":
 		fallthrough
+	case "nodejs18.x":
+		fallthrough
 	case "go1.x":
-		generateServerlessZIPArtifactsPythonGolang(experimentID, provider, runtime, functionName, functionImageSizeMB)
+		generateServerlessZIPArtifactsPythonGolangNode(experimentID, provider, runtime, functionName, functionImageSizeMB)
 	case "java11":
 		generateServerlessZIPArtifactsJava(experimentID, provider, runtime, functionName, functionImageSizeMB)
 	}
 }
 
-func generateServerlessZIPArtifactsPythonGolang(experimentID int, provider string, runtime string, functionName string, functionImageSizeMB float64) {
+func generateServerlessZIPArtifactsPythonGolangNode(experimentID int, provider string, runtime string, functionName string, functionImageSizeMB float64) {
 	defaultBinaryName := map[string]string{
-		"python3.9": "main.py",
-		"go1.x":     "main",
+		"python3.9":  "main.py",
+		"go1.x":      "main",
+		"nodejs18.x": "index.js",
 	}
 	binaryPath := fmt.Sprintf("setup/deployment/raw-code/serverless/%s/artifacts/%s/%s", provider, functionName, defaultBinaryName[runtime])
 

--- a/src/setup/deployment/raw-code/serverless/aws/hellonode/index.js
+++ b/src/setup/deployment/raw-code/serverless/aws/hellonode/index.js
@@ -1,0 +1,22 @@
+// Handler
+exports.handler = async function (event, context) {
+  let incrementLimit = 0;
+  if (event.queryStringParameters.incrementLimit) {
+    incrementLimit = event.queryStringParameters.incrementLimit;
+  }
+  simulateWork(incrementLimit);
+  const res = {
+    statusCode: 200,
+    headers: { "Content-Type": "application/json" },
+    body: {
+      RequestID: context.aws_request_id,
+      TimestampChain: [Date.now().toString()],
+    },
+  };
+
+  return JSON.stringify(res);
+};
+
+const simulateWork = (incrementLimit) => {
+  for (let i = 0; i < incrementLimit; i++) {}
+};

--- a/src/setup/deployment/raw-code/serverless/aws/helloruby/function.rb
+++ b/src/setup/deployment/raw-code/serverless/aws/helloruby/function.rb
@@ -1,0 +1,21 @@
+require 'json'
+
+def handler(event:, context:)
+  incrementLimit = 0
+  if event['queryStringParameters'] != nil
+    if event['queryStringParameters']['IncrementLimit'] != nil
+      incrementLimit = event['queryStringParameters']['IncrementLimit'].to_i
+    end
+  end
+
+  simulateWork(incrementLimit)
+
+  { RequestID: context.aws_request_id, TimestampChain: [ DateTime.now.strftime('%Q') ] }
+end
+
+def simulateWork(incrementLimit)
+  i = 0
+  while i < incrementLimit
+    i += 1
+  end
+end


### PR DESCRIPTION
This PR adds working basic function code for two additional runtimes in AWS, **Node** and **Ruby**. This is in preparation of handling #342 to perform experiments on different runtimes. With this PR, experiments can be conducted on the following runtimes for AWS:

- Python
- Go
- Java
- **Node (New)**
- **Ruby (New)**

## Changes
- Add `helloruby` raw-code and test experiment JSON file for AWS
- Add `hellonode` raw-code and test experiments JSON file for AWS
- Add zipping support for Node and Ruby runtimes (AWS)
- Add unit tests for generating ZIP files for Node and Ruby runtimes (AWS)
- Add building of Node and Ruby (As they do not need to be compiled, it is just a `cp` similar to Python
- Rename `generateServerlessZIPArtifactsPythonGolang` to `generateServerlessZIPArtifactsGeneral`