### PR TITLE
add support for `FunctionImageSizeMB` configuration on GCR experiments

### DIFF
--- a/experiments/tests/gcr/hellopy.json
+++ b/experiments/tests/gcr/hellopy.json
@@ -16,7 +16,7 @@
       "DesiredServiceTimes": [
         "0ms"
       ],
-      "FunctionImageSizeMB": 24
+      "FunctionImageSizeMB": 60
     },
     {
       "Title": "parallelism2",
@@ -31,7 +31,7 @@
       "DesiredServiceTimes": [
         "0ms"
       ],
-      "FunctionImageSizeMB": 48,
+      "FunctionImageSizeMB": 100,
       "Parallelism": 2
     }
   ]

--- a/src/setup/assign-endpoints.go
+++ b/src/setup/assign-endpoints.go
@@ -43,7 +43,7 @@ func assignEndpoints(availableEndpoints []connection.Endpoint, experiment *SubEx
 		experiment.FunctionImageSizeMB, assignedHandler = deployment.SetupDeployment(
 			fmt.Sprintf("setup/deployment/raw-code/functions/%s/%s", experiment.Function, provider),
 			provider,
-			util.MBToBytes(experiment.FunctionImageSizeMB),
+			util.MebibyteToBytes(experiment.FunctionImageSizeMB),
 			experiment.PackageType,
 			experiment.ID,
 			experiment.Function,

--- a/src/setup/deployment/connection/connection.go
+++ b/src/setup/deployment/connection/connection.go
@@ -29,13 +29,13 @@ import (
 	log "github.com/sirupsen/logrus"
 	"io"
 	"path"
-	"strings"
-	"time"
 	"stellar/setup/deployment/connection/amazon"
 	"stellar/util"
+	"strings"
+	"time"
 )
 
-//Endpoint is the schema for the configuration of provider endpoints.
+// Endpoint is the schema for the configuration of provider endpoints.
 type Endpoint struct {
 	GatewayID        string  `json:"GatewayID"`
 	FunctionMemoryMB int64   `json:"FunctionMemoryMB"`
@@ -43,7 +43,7 @@ type Endpoint struct {
 	PackageType      string  `json:"PackageType"`
 }
 
-//ServerlessInterface creates an interface through which to interact with various providers
+// ServerlessInterface creates an interface through which to interact with various providers
 type ServerlessInterface struct {
 	//ListAPIs will list all endpoints corresponding to all serverless functions.
 	ListAPIs func() []Endpoint
@@ -60,10 +60,10 @@ type ServerlessInterface struct {
 	UpdateFunction func(packageType string, uniqueID string, memoryAssigned int64)
 }
 
-//Singleton allows the client to interact with various serverless actions
+// Singleton allows the client to interact with various serverless actions
 var Singleton *ServerlessInterface
 
-//Initialize will create a new provider connection to interact with
+// Initialize will create a new provider connection to interact with
 func Initialize(provider string, endpointsDirectoryPath string, apiTemplatePath string) {
 	switch strings.ToLower(provider) {
 	case "aws":
@@ -103,7 +103,7 @@ func setupAWSConnection(apiTemplatePath string) {
 							GatewayID:        strings.Split(*function.FunctionName, "_")[1],
 							FunctionMemoryMB: *function.MemorySize,
 							PackageType:      *function.PackageType,
-							ImageSizeMB:      util.BytesToMB(*function.CodeSize),
+							ImageSizeMB:      util.BytesToMebibyte(*function.CodeSize),
 						})
 					}
 				}

--- a/src/setup/deployment/connection/connection_aws_test.go
+++ b/src/setup/deployment/connection/connection_aws_test.go
@@ -190,7 +190,7 @@ func setupDeployment(packageType string, function string) (float64, string) {
 	deployedImageSizeMB, binaryPath := deployment.SetupDeployment(
 		fmt.Sprintf("../raw-code/functions/producer-consumer/%s", aws),
 		aws,
-		util.MBToBytes(0.),
+		util.MebibyteToBytes(0.),
 		packageType,
 		0,
 		function,

--- a/src/setup/deployment/packaging/container.go
+++ b/src/setup/deployment/packaging/container.go
@@ -63,8 +63,8 @@ func SetupContainerImageDeployment(function string, provider string, compressedI
 
 	taggedImage := fmt.Sprintf("%s_%v_stellar:latest", function, compressedImageSizeMebibyte)
 	imageName := fmt.Sprintf("%s/%s", privateRepoURI, taggedImage)
-	if builtImages[function] {
-		log.Infof("Container image for function %q is already built. Skipping...", function)
+	if builtImages[taggedImage] {
+		log.Infof("Container image for function %q is already built. Skipping...", taggedImage)
 		return imageName
 	}
 
@@ -78,6 +78,6 @@ func SetupContainerImageDeployment(function string, provider string, compressedI
 	if provider == "aws" {
 		amazon.AWSSingletonInstance.ImageURI = imageName
 	}
-	builtImages[function] = true
+	builtImages[taggedImage] = true
 	return imageName
 }

--- a/src/setup/deployment/packaging/container.go
+++ b/src/setup/deployment/packaging/container.go
@@ -36,7 +36,7 @@ var privateRepoURI string = ""
 var loggedIn bool = false
 
 // SetupContainerImageDeployment will package the function using container images and push to registry
-func SetupContainerImageDeployment(function string, provider string) string {
+func SetupContainerImageDeployment(function string, provider string, compressedImageSizeMebibyte float64) string {
 	functionDir := fmt.Sprintf("setup/deployment/raw-code/serverless/%s/%s", provider, function)
 	switch provider {
 	case "aws":
@@ -61,7 +61,7 @@ func SetupContainerImageDeployment(function string, provider string) string {
 		log.Fatalf("Provider %s does not support container image deployment.", provider)
 	}
 
-	taggedImage := fmt.Sprintf("%s_stellar:latest", function)
+	taggedImage := fmt.Sprintf("%s_%v_stellar:latest", function, compressedImageSizeMebibyte)
 	imageName := fmt.Sprintf("%s/%s", privateRepoURI, taggedImage)
 	if builtImages[function] {
 		log.Infof("Container image for function %q is already built. Skipping...", function)

--- a/src/setup/deployment/packaging/test/zip_test.go
+++ b/src/setup/deployment/packaging/test/zip_test.go
@@ -24,13 +24,13 @@ func (s *ZipTestSuite) SetupSuite() {
 func (s *ZipTestSuite) TestGenerateFillerFile() {
 	expectedFillerFileSizeMB := 30.0
 
-	packaging.GenerateFillerFile(1, "filler.file", util.MBToBytes(expectedFillerFileSizeMB))
+	packaging.GenerateFillerFile(1, "filler.file", util.MebibyteToBytes(expectedFillerFileSizeMB))
 
 	fileInfo, err := os.Stat("filler.file")
 	if err != nil {
 		assert.Fail(s.T(), "Could not obtain file info of ZIP artifact")
 	}
-	actualFillerFileSize := util.BytesToMB(fileInfo.Size())
+	actualFillerFileSize := util.BytesToMebibyte(fileInfo.Size())
 	assert.InDelta(s.T(), expectedFillerFileSizeMB, actualFillerFileSize, 0.1)
 
 	err = os.Remove("filler.file")
@@ -47,7 +47,7 @@ func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsPython() {
 	if err != nil {
 		assert.Fail(s.T(), "Could not obtain file info of ZIP artifact")
 	}
-	assert.InDelta(s.T(), 50, util.BytesToMB(fileInfo.Size()), 0.1)
+	assert.InDelta(s.T(), 50, util.BytesToMebibyte(fileInfo.Size()), 0.1)
 }
 
 func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsGolang() {
@@ -58,7 +58,7 @@ func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsGolang() {
 	if err != nil {
 		assert.Fail(s.T(), "Could not obtain file info of ZIP artifact")
 	}
-	assert.InDelta(s.T(), 50, util.BytesToMB(fileInfo.Size()), 0.1)
+	assert.InDelta(s.T(), 50, util.BytesToMebibyte(fileInfo.Size()), 0.1)
 }
 
 func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsJava() {
@@ -69,7 +69,7 @@ func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsJava() {
 	if err != nil {
 		assert.Fail(s.T(), "Could not obtain file info of ZIP artifact")
 	}
-	assert.InDelta(s.T(), 50, util.BytesToMB(fileInfo.Size()), 0.1)
+	assert.InDelta(s.T(), 50, util.BytesToMebibyte(fileInfo.Size()), 0.1)
 }
 
 func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsNode() {
@@ -80,7 +80,7 @@ func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsNode() {
 	if err != nil {
 		assert.Fail(s.T(), "Could not obtain file info of ZIP artifact")
 	}
-	assert.InDelta(s.T(), 50, util.BytesToMB(fileInfo.Size()), 0.1)
+	assert.InDelta(s.T(), 50, util.BytesToMebibyte(fileInfo.Size()), 0.1)
 }
 
 func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsRuby() {
@@ -91,7 +91,7 @@ func (s *ZipTestSuite) TestGenerateServerlessZipArtifactsRuby() {
 	if err != nil {
 		assert.Fail(s.T(), "Could not obtain file info of ZIP artifact")
 	}
-	assert.InDelta(s.T(), 50, util.BytesToMB(fileInfo.Size()), 0.1)
+	assert.InDelta(s.T(), 50, util.BytesToMebibyte(fileInfo.Size()), 0.1)
 }
 
 func TestZipTestSuite(t *testing.T) {

--- a/src/setup/deployment/packaging/zip.go
+++ b/src/setup/deployment/packaging/zip.go
@@ -35,7 +35,7 @@ import (
 
 // SetupZIPDeployment will package the function using ZIP
 func SetupZIPDeployment(provider string, deploymentSizeBytes int64, zipPath string) {
-	deploymentSizeMB := util.BytesToMB(deploymentSizeBytes)
+	deploymentSizeMB := util.BytesToMebibyte(deploymentSizeBytes)
 	switch provider {
 	case "aws":
 		if deploymentSizeMB > 50. {
@@ -128,7 +128,7 @@ func generateServerlessZIPArtifactsGeneral(experimentID int, provider string, ru
 	binaryPath := fmt.Sprintf("setup/deployment/raw-code/serverless/%s/artifacts/%s/%s", provider, functionName, defaultBinaryName[runtime])
 
 	currentSizeInBytes := GetZippedBinaryFileSize(experimentID, binaryPath)
-	targetSizeInBytes := util.MBToBytes(functionImageSizeMB)
+	targetSizeInBytes := util.MebibyteToBytes(functionImageSizeMB)
 
 	fillerFileSize := CalculateFillerFileSizeInBytes(currentSizeInBytes, targetSizeInBytes)
 	fillerFilePath := fmt.Sprintf("setup/deployment/raw-code/serverless/%s/artifacts/%s/filler.file", provider, functionName)
@@ -146,7 +146,7 @@ func generateServerlessZIPArtifactsJava(experimentID int, provider string, runti
 	}
 
 	currentSizeInBytes := fileInfo.Size()
-	targetSizeInBytes := util.MBToBytes(functionImageSizeMB)
+	targetSizeInBytes := util.MebibyteToBytes(functionImageSizeMB)
 
 	fillerFileSize := CalculateFillerFileSizeInBytes(currentSizeInBytes, targetSizeInBytes)
 	fillerFilePath := fmt.Sprintf("setup/deployment/raw-code/serverless/%s/artifacts/%s/filler.file", provider, functionName)
@@ -158,14 +158,14 @@ func generateServerlessZIPArtifactsJava(experimentID int, provider string, runti
 func CalculateFillerFileSizeInBytes(currentSizeInBytes int64, targetSizeInBytes int64) int64 {
 	if targetSizeInBytes == 0 {
 		log.Infof("Desired image size is set to default (0MB), assigning size of zipped binary (%vMB)...",
-			util.BytesToMB(currentSizeInBytes),
+			util.BytesToMebibyte(currentSizeInBytes),
 		)
 		targetSizeInBytes = currentSizeInBytes
 	}
 	if targetSizeInBytes < currentSizeInBytes {
 		log.Fatalf("Total size (~%vMB) cannot be smaller than zipped binary size (~%vMB).",
-			util.BytesToMB(targetSizeInBytes),
-			util.BytesToMB(currentSizeInBytes),
+			util.BytesToMebibyte(targetSizeInBytes),
+			util.BytesToMebibyte(currentSizeInBytes),
 		)
 	}
 	return targetSizeInBytes - currentSizeInBytes

--- a/src/setup/deployment/raw-code/serverless/gcr/hellopy/Dockerfile
+++ b/src/setup/deployment/raw-code/serverless/gcr/hellopy/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.7-alpine
 
 RUN pip install Flask gunicorn
 

--- a/src/setup/deployment/raw-code/serverless/gcr/hellopy/app.py
+++ b/src/setup/deployment/raw-code/serverless/gcr/hellopy/app.py
@@ -1,10 +1,10 @@
+import json
 import os
 import time
-import json
-
 from flask import Flask, request
 
 app = Flask(__name__)
+
 
 @app.route('/')
 def hello_world():
@@ -33,5 +33,6 @@ def simulate_work(incr):
     while num < incr:
         num += 1
 
+
 if __name__ == "__main__":
-   app.run(debug=True,host='0.0.0.0',port=int(os.environ.get('PORT', 8080)))
+    app.run(debug=True, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))

--- a/src/setup/deployment/run.go
+++ b/src/setup/deployment/run.go
@@ -45,7 +45,7 @@ func SetupDeployment(rawCodePath string, provider string, deploymentSizeBytes in
 		if deploymentSizeBytes == 0 {
 			log.Infof("[sub-experiment %d] Desired image size is set to default (0MB), assigning size of zipped binary (%vMB)...",
 				experimentID,
-				util.BytesToMB(zippedBinaryFileSizeBytes),
+				util.BytesToMebibyte(zippedBinaryFileSizeBytes),
 			)
 			deploymentSizeBytes = zippedBinaryFileSizeBytes
 		}
@@ -53,8 +53,8 @@ func SetupDeployment(rawCodePath string, provider string, deploymentSizeBytes in
 		if deploymentSizeBytes < zippedBinaryFileSizeBytes {
 			log.Fatalf("[sub-experiment %d] Total size (~%vMB) cannot be smaller than zipped binary size (~%vMB).",
 				experimentID,
-				util.BytesToMB(deploymentSizeBytes),
-				util.BytesToMB(zippedBinaryFileSizeBytes),
+				util.BytesToMebibyte(deploymentSizeBytes),
+				util.BytesToMebibyte(zippedBinaryFileSizeBytes),
 			)
 		}
 
@@ -62,7 +62,7 @@ func SetupDeployment(rawCodePath string, provider string, deploymentSizeBytes in
 		zipPath := packaging.GenerateZIP(experimentID, fillerFilePath, binaryPath, "benchmarking.zip")
 		packaging.SetupZIPDeployment(provider, deploymentSizeBytes, zipPath)
 
-		return util.BytesToMB(deploymentSizeBytes), handlerPath
+		return util.BytesToMebibyte(deploymentSizeBytes), handlerPath
 	case "Image":
 		log.Warn("Container image deployment does not support code size verification on AWS, making the image size benchmarks unreliable.")
 
@@ -74,7 +74,7 @@ func SetupDeployment(rawCodePath string, provider string, deploymentSizeBytes in
 		log.Fatalf("[sub-experiment %d] Unrecognized package type: %s", experimentID, packageType)
 	}
 
-	return util.BytesToMB(deploymentSizeBytes), ""
+	return util.BytesToMebibyte(deploymentSizeBytes), ""
 }
 
 func getExecutableInfo(rawCodePath string, experimentID int, function string) (int64, string, string) {

--- a/src/setup/run.go
+++ b/src/setup/run.go
@@ -192,7 +192,7 @@ func deploySubExperimentParallelismInBatches(config *Configuration, serverlessDi
 
 				deploymentCodePath := filepath.Join(deploymentDir, subExperiment.PackagePattern)
 				currentSizeInBytes := packaging.GetZippedBinaryFileSize(subExperiment.ID, deploymentCodePath)
-				targetSizeInBytes := util.MBToBytes(subExperiment.FunctionImageSizeMB)
+				targetSizeInBytes := util.MebibyteToBytes(subExperiment.FunctionImageSizeMB)
 
 				fillerFileSize := packaging.CalculateFillerFileSizeInBytes(currentSizeInBytes, targetSizeInBytes)
 				fillerFilePath := filepath.Join(deploymentDir, "filler.file")

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -41,13 +41,13 @@ func ReadFile(path string) *os.File {
 	return file
 }
 
-// BytesToMB transforms bytes into megabytes
-func BytesToMB(sizeBytes int64) float64 {
+// BytesToMebibyte transforms bytes into mebibyte
+func BytesToMebibyte(sizeBytes int64) float64 {
 	return float64(sizeBytes) / 1024. / 1024.
 }
 
-// MBToBytes transforms megabytes into bytes
-func MBToBytes(sizeMB float64) int64 {
+// MebibyteToBytes transforms mebibyte into bytes
+func MebibyteToBytes(sizeMB float64) int64 {
 	return int64(sizeMB) * 1024 * 1024
 }
 

--- a/src/util/util_test.go
+++ b/src/util/util_test.go
@@ -29,14 +29,14 @@ import (
 )
 
 func TestBytesToMB(t *testing.T) {
-	res := BytesToMB(1024. * 1024.)
+	res := BytesToMebibyte(1024. * 1024.)
 	require.Equal(t, 1., res)
 }
 
 func TestMBToBytes(t *testing.T) {
-	res := MBToBytes(7.)
-	require.Equal(t, int64(7 * 1024 * 1024), res)
+	res := MebibyteToBytes(7.)
+	require.Equal(t, int64(7*1024*1024), res)
 
-	res = MBToBytes(0.)
+	res = MebibyteToBytes(0.)
 	require.Equal(t, int64(0), res)
 }


### PR DESCRIPTION
This PR is related to #343 and adds filler files to GCR container deployments.

### Notes

The size of the compressed image of the `hellopy` function for GCR on Docker Hub was experimentally found to be approximately 21.84 MiB. Subtracting this from the value of `FunctionImageSizeMB`, we obtain the size of the filler file that needs to be generated.

### Changes

- switch to `python:3.7-alpine` for GCR `hellopy` base image to reduce its final container image size
- generate filler files based on `FunctionImageSizeMB` parameter in the `src/setup/deployment/raw-code/serverless/gcr/hellopy` directory
- upload separate images to Docker Hub for each sub-experiment, since their target image sizes could be different
- renamed storage size conversion functions in `util` package by replacing `MB` with `Mebibyte` to avoid ambiguity, since powers of 2 are used in the actual implementation
- adjusted `FunctionImageSizeMB` parameter in configuration file for end to end test to 60 MiB and 100 MiB respectively