### PR TITLE
use unique names for AWS CloudFormation stacks

### DIFF
--- a/src/setup/run.go
+++ b/src/setup/run.go
@@ -114,7 +114,8 @@ func ProvisionFunctionsServerlessAWS(config *Configuration, serverlessDirPath st
 	slsConfig := &Serverless{}
 	builder := &building.Builder{}
 
-	slsConfig.CreateHeaderConfig(config, "STeLLAR")
+	randomTag := util.GenerateRandLowercaseLetters(5)
+	slsConfig.CreateHeaderConfig(config, fmt.Sprintf("STeLLAR-%s", randomTag))
 	slsConfig.packageIndividually()
 
 	for index, subExperiment := range config.SubExperiments {
@@ -123,7 +124,6 @@ func ProvisionFunctionsServerlessAWS(config *Configuration, serverlessDirPath st
 
 		// TODO: build the functions (Java and Golang)
 		artifactPathRelativeToServerlessConfigFile := builder.BuildFunction(config.Provider, subExperiment.Function, subExperiment.Runtime)
-		randomTag := util.GenerateRandLowercaseLetters(5)
 		slsConfig.AddFunctionConfigAWS(&config.SubExperiments[index], index, randomTag, artifactPathRelativeToServerlessConfigFile)
 
 		// generate filler files and zip used as Serverless artifacts


### PR DESCRIPTION
This PR modifies AWS deployments to use a unique Serverless Framework service name (also known as CloudFormation stack name) for each experiment.

This should help to prevent errors like:
> time="2023-11-15T04:02:46Z" level=info msg="Command combined output: \nDeploying STeLLAR to stage dev (us-west-1)\n\n× Stack STeLLAR-dev failed to deploy (4s)\nEnvironment: linux, node 16.16.0, framework 3.36.0, plugin 7.1.0, SDK 4.4.0\nCredentials: Local, environment variables\nDocs:        docs.serverless.com\nSupport:     forum.serverless.com\nBugs:        github.com/serverless/serverless/issues\n\nError:\nStack:arn:aws:cloudformation:us-west-1:356764711652:stack/STeLLAR-dev/a91e2b10-836b-11ee-a945-024a36635ec9 is in UPDATE_IN_PROGRESS state and can not be updated.\n\n"