### PR TITLE
reduce Azure parallel deployments

### DIFF
--- a/src/setup/run.go
+++ b/src/setup/run.go
@@ -161,7 +161,7 @@ func ProvisionFunctionsServerlessAzure(config *Configuration, serverlessDirPath 
 			config.SubExperiments[subExperimentIndex].Endpoints = []EndpointInfo{}
 		}
 
-		deploySubExperimentParallelismInBatches(config, serverlessDirPath, randomExperimentTag, subExperimentIndex, 3)
+		deploySubExperimentParallelismInBatches(config, serverlessDirPath, randomExperimentTag, subExperimentIndex, 1)
 	}
 }
 


### PR DESCRIPTION
Deployments to Azure were previously split into batches and deployed in parallel. However, with image size experiments of up to 100MB, many issues were observed with STeLLAR on self-hosted runners as the process is frequently terminated with an exit code of 137 (terminated externally because of its memory consumption).

> /home/azureuser/actions-runner/_work/_temp/c45ce5b4-fc17-4899-bbe8-d82d848e5355.sh: line 1: 119177 Killed                  ./stellar -c ../experiments/image-sizes/azure-image-size-100mb.json
Error: Process completed with exit code 137.

This PR reduces the number of parallel Azure deployments, until larger self-hosted runners are provisioned in the future. A typical cold experiment will now take about 2h longer than before.