### PR TITLE
Add experiment JSON files for continuous benchmarking runtime experiments

### DIFF
--- a/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/aws/warm-hellogo-zip-aws.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/aws/warm-hellogo-zip-aws.json
@@ -1,0 +1,22 @@
+{
+  "Sequential": false,
+  "Provider": "aws",
+  "Runtime": "go1.x",
+  "SubExperiments": [
+    {
+      "Title": "warm-hellogo-zip-aws",
+      "Function": "hellogo",
+	  "Handler": "main",
+	  "PackageType": "Zip",
+	  "PackagePattern": "main.go",
+      "Bursts": 100,
+      "BurstSizes": [
+        1
+      ],
+      "IATSeconds": 3,
+      "DesiredServiceTimes": [
+        "0ms"
+      ]
+    }
+  ]
+}

--- a/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/aws/warm-hellojava-zip-aws.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/aws/warm-hellojava-zip-aws.json
@@ -1,0 +1,21 @@
+{
+  "Sequential": false,
+  "Provider": "aws",
+  "Runtime": "java11",
+  "SubExperiments": [
+    {
+      "Title": "warm-hellojava-zip-aws",
+      "Function": "hellojava",
+	  "Handler": "org.hellojava.Handler",
+	  "PackageType": "Zip",
+      "Bursts": 100,
+      "BurstSizes": [
+        1
+      ],
+      "IATSeconds": 3,
+      "DesiredServiceTimes": [
+        "0ms"
+      ]
+    }
+  ]
+}

--- a/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/aws/warm-hellonode-zip-aws.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/aws/warm-hellonode-zip-aws.json
@@ -1,0 +1,22 @@
+{
+  "Sequential": false,
+  "Provider": "aws",
+  "Runtime": "nodejs18.x",
+  "SubExperiments": [
+    {
+      "Title": "warm-hellonode-zip-aws",
+      "Function": "hellonode",
+	  "Handler": "index.handler",
+	  "PackageType": "Zip",
+	  "PackagePattern": "index.js",
+      "Bursts": 100,
+      "BurstSizes": [
+        1
+      ],
+      "IATSeconds": 3,
+      "DesiredServiceTimes": [
+        "0ms"
+      ]
+    }
+  ]
+}

--- a/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/aws/warm-hellopy-zip-aws.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/aws/warm-hellopy-zip-aws.json
@@ -1,0 +1,23 @@
+{
+  "Sequential": false,
+  "Provider": "aws",
+  "Runtime": "python3.9",
+  "SubExperiments": [
+    {
+      "Title": "warm-hellopy-zip-aws",
+      "RepurposeIdentifier": "hellopy-zip-img0MB",
+      "Function": "hellopy",
+	  "Handler": "main.lambda_handler",
+	  "PackageType": "Zip",
+	  "PackagePattern": "main.py",
+      "Bursts": 100,
+      "BurstSizes": [
+        1
+      ],
+      "IATSeconds": 3,
+      "DesiredServiceTimes": [
+        "0ms"
+      ]
+    }
+  ]
+}

--- a/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/aws/warm-helloruby-zip-aws.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/aws/warm-helloruby-zip-aws.json
@@ -1,0 +1,22 @@
+{
+  "Sequential": false,
+  "Provider": "aws",
+  "Runtime": "ruby3.2",
+  "SubExperiments": [
+    {
+      "Title": "warm-helloruby-zip-aws",
+      "Function": "helloruby",
+	  "Handler": "function.handler",
+	  "PackageType": "Zip",
+	  "PackagePattern": "function.rb",
+      "Bursts": 100,
+      "BurstSizes": [
+        1
+      ],
+      "IATSeconds": 3,
+      "DesiredServiceTimes": [
+        "0ms"
+      ]
+    }
+  ]
+}

--- a/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/gcr/warm-hellogo-img-gcr.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/gcr/warm-hellogo-img-gcr.json
@@ -1,0 +1,21 @@
+{
+  "Sequential": false,
+  "Provider": "gcr",
+  "Runtime": "go1.x",
+  "SubExperiments": [
+    {
+      "Title": "warm-hellogo-img-gcr",
+      "Function": "hellogo",
+	  "Handler": "Dockerfile",
+	  "PackageType": "Container",
+      "Bursts": 100,
+      "BurstSizes": [
+        1
+      ],
+      "IATSeconds": 3,
+      "DesiredServiceTimes": [
+        "0ms"
+      ]
+    }
+  ]
+}

--- a/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/gcr/warm-hellojava-img-gcr.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/gcr/warm-hellojava-img-gcr.json
@@ -1,0 +1,21 @@
+{
+  "Sequential": false,
+  "Provider": "gcr",
+  "Runtime": "java11",
+  "SubExperiments": [
+    {
+      "Title": "warm-hellojava-img-gcr",
+      "Function": "hellojava",
+	  "Handler": "Dockerfile",
+	  "PackageType": "Container",
+      "Bursts": 100,
+      "BurstSizes": [
+        1
+      ],
+      "IATSeconds": 3,
+      "DesiredServiceTimes": [
+        "0ms"
+      ]
+    }
+  ]
+}

--- a/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/gcr/warm-hellonode-img-gcr.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/gcr/warm-hellonode-img-gcr.json
@@ -1,0 +1,21 @@
+{
+  "Sequential": false,
+  "Provider": "gcr",
+  "Runtime": "node",
+  "SubExperiments": [
+    {
+      "Title": "warm-hellonode-img-gcr",
+      "Function": "hellonode",
+	  "Handler": "Dockerfile",
+	  "PackageType": "Container",
+      "Bursts": 100,
+      "BurstSizes": [
+        1
+      ],
+      "IATSeconds": 3,
+      "DesiredServiceTimes": [
+        "0ms"
+      ]
+    }
+  ]
+}

--- a/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/gcr/warm-hellopy-img-gcr.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/gcr/warm-hellopy-img-gcr.json
@@ -1,0 +1,22 @@
+{
+  "Sequential": false,
+  "Provider": "gcr",
+  "Runtime": "python3.9",
+  "SubExperiments": [
+    {
+      "Title": "warm-hellopy-img-gcr",
+      "Function": "hellopy",
+	  "Handler": "Dockerfile",
+	  "PackageType": "Container",
+	  "PackagePattern": "lambda_function.py",
+      "Bursts": 100,
+      "BurstSizes": [
+        1
+      ],
+      "IATSeconds": 3,
+      "DesiredServiceTimes": [
+        "0ms"
+      ]
+    }
+  ]
+}

--- a/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/gcr/warm-hellorust-img-gcr.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/gcr/warm-hellorust-img-gcr.json
@@ -1,0 +1,21 @@
+{
+  "Sequential": false,
+  "Provider": "gcr",
+  "Runtime": "rust",
+  "SubExperiments": [
+    {
+      "Title": "warm-hellorust-img-gcr",
+      "Function": "hellorust",
+	  "Handler": "Dockerfile",
+	  "PackageType": "Container",
+      "Bursts": 100,
+      "BurstSizes": [
+        1
+      ],
+      "IATSeconds": 3,
+      "DesiredServiceTimes": [
+        "0ms"
+      ]
+    }
+  ]
+}

--- a/src/setup/deployment/raw-code/serverless/gcr/hellopy/Dockerfile
+++ b/src/setup/deployment/raw-code/serverless/gcr/hellopy/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.7-slim
 
 RUN pip install Flask gunicorn
 

--- a/src/setup/deployment/raw-code/serverless/gcr/hellopy/app.py
+++ b/src/setup/deployment/raw-code/serverless/gcr/hellopy/app.py
@@ -1,10 +1,10 @@
-import json
 import os
 import time
+import json
+
 from flask import Flask, request
 
 app = Flask(__name__)
-
 
 @app.route('/')
 def hello_world():
@@ -33,6 +33,5 @@ def simulate_work(incr):
     while num < incr:
         num += 1
 
-
 if __name__ == "__main__":
-    app.run(debug=True, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))
+   app.run(debug=True,host='0.0.0.0',port=int(os.environ.get('PORT', 8080)))


### PR DESCRIPTION
This PR adds experiment JSON files to `continuous-benchmarking` for running scheduled experiments for different runtimes.

# Changes
- Add experiment JSON files to `continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/`