### PR TITLE
upgrade Azure Functions runtime version to 4.x

### DIFF
--- a/src/setup/integration-test/aliyun-integration-test-serverless.yml
+++ b/src/setup/integration-test/aliyun-integration-test-serverless.yml
@@ -3,23 +3,23 @@ service: stellar-aliyun-itgr-test
 frameworkVersion: "3"
 
 provider:
-  name: aliyun
-  runtime: python3.9
-  credentials: ~/.aliyuncli/credentials
-  region: us-west-1
+    name: aliyun
+    runtime: python3.9
+    credentials: ~/.aliyuncli/credentials
+    region: us-west-1
 
 plugins:
-  - serverless-aliyun-function-compute
+    - serverless-aliyun-function-compute
 
 functions:
-  hello:
-    handler: main.main
-    runtime: python3.9
-    package:
-      patterns:
-        - "!**"
-        - main.py
-    events:
-      - http:
-          path: /foo
-          method: get
+    hello:
+        handler: main.main
+        runtime: python3.9
+        package:
+            patterns:
+                - "!**"
+                - main.py
+        events:
+            - http:
+                path: /foo
+                method: get

--- a/src/setup/integration-test/aws-integration-test-serverless.yml
+++ b/src/setup/integration-test/aws-integration-test-serverless.yml
@@ -1,11 +1,15 @@
 service: TestService
+
 frameworkVersion: "3"
+
 provider:
     name: aws
     runtime: python3.9
     region: us-west-1
+
 package:
     individually: true
+
 functions:
     testFunction1:
         handler: hellopy/lambda_function.lambda_handler

--- a/src/setup/integration-test/azure-integration-test-serverless.yml
+++ b/src/setup/integration-test/azure-integration-test-serverless.yml
@@ -3,21 +3,23 @@ service: stellar-azure-itgr-test
 frameworkVersion: "3"
 
 provider:
-  name: azure
-  region: West US
-  runtime: python3.8
+    name: azure
+    region: West US
+    runtime: python3.8
+    functionApp:
+        extensionVersion: '~4'
 
 plugins:
-  - serverless-azure-functions
+    - serverless-azure-functions
 
 functions:
-  stellar-azure-integration-test-0:
-    package:
-      patterns:
-        - 'main.py'
-    handler: main.main
-    events:
-      - http: true
-        methods:
-          - GET
-        authLevel: anonymous
+    stellar-azure-integration-test-0:
+        package:
+            patterns:
+                - 'main.py'
+        handler: main.main
+        events:
+            -   http: true
+                methods:
+                    - GET
+                authLevel: anonymous

--- a/src/setup/serverless-config.go
+++ b/src/setup/serverless-config.go
@@ -25,10 +25,15 @@ type Serverless struct {
 }
 
 type Provider struct {
-	Name        string `yaml:"name"`
-	Runtime     string `yaml:"runtime"`
-	Region      string `yaml:"region"`
-	Credentials string `yaml:"credentials,omitempty"`
+	Name        string      `yaml:"name"`
+	Runtime     string      `yaml:"runtime"`
+	Region      string      `yaml:"region"`
+	Credentials string      `yaml:"credentials,omitempty"`
+	FunctionApp FunctionApp `yaml:"functionApp,omitempty"`
+}
+
+type FunctionApp struct {
+	ExtensionVersion string `yaml:"extensionVersion"`
 }
 
 type Package struct {
@@ -126,14 +131,22 @@ func (s *Serverless) CreateHeaderConfig(config *Configuration, serviceName strin
 	s.Service = serviceName
 	s.FrameworkVersion = "3"
 
-	if config.Provider == "aliyun" {
+	switch config.Provider {
+	case "azure":
+		s.Provider = Provider{
+			Name:        config.Provider,
+			Runtime:     config.Runtime,
+			Region:      region,
+			FunctionApp: FunctionApp{ExtensionVersion: "~4"},
+		}
+	case "aliyun":
 		s.Provider = Provider{
 			Name:        config.Provider,
 			Runtime:     config.Runtime,
 			Region:      region,
 			Credentials: "~/.aliyuncli/credentials",
 		}
-	} else {
+	default:
 		s.Provider = Provider{
 			Name:    config.Provider,
 			Runtime: config.Runtime,


### PR DESCRIPTION
While the [serverless-azure-functions](https://www.npmjs.com/package/serverless-azure-functions) plugin deploys Azure Functions with a runtime version of 3.x by default, this has been deprecated. This PR implements a workaround proposed in an open issue [here](https://github.com/serverless/serverless-azure-functions/issues/592).