### PR TITLE
Add support for nodejs18 runtime in Azure Functions

### DIFF
--- a/experiments/tests/azure/hellonode.json
+++ b/experiments/tests/azure/hellonode.json
@@ -1,0 +1,22 @@
+{
+  "Sequential": false,
+  "Provider": "azure",
+  "Runtime": "nodejs18",
+  "SubExperiments": [
+    {
+      "Title": "warm-hellonode-zip-azure",
+      "Function": "hellonode",
+      "Handler": "index.handler",
+      "PackageType": "Zip",
+      "PackagePattern": "index.js",
+      "Bursts": 100,
+      "BurstSizes": [
+        1
+      ],
+      "DesiredServiceTimes": [
+        "0ms"
+      ],
+      "FunctionImageSizeMB": 24
+    }
+  ]
+}

--- a/src/setup/building/builder.go
+++ b/src/setup/building/builder.go
@@ -38,6 +38,8 @@ func (b *Builder) BuildFunction(provider string, functionName string, runtime st
 		buildJava(functionName, functionDir, artifactDir)
 	case "go1.x":
 		buildGolang(functionName, functionDir, artifactDir)
+	case "nodejs18":
+		fallthrough
 	case "nodejs18.x":
 		copyNodeJSFile(functionName, functionDir, artifactDir)
 	case "ruby3.2":

--- a/src/setup/deployment/raw-code/serverless/azure/hellonode/index.js
+++ b/src/setup/deployment/raw-code/serverless/azure/hellonode/index.js
@@ -1,0 +1,23 @@
+async function handler(context, request) {
+  let q = request.query;
+  let incrementLimit = 0;
+  if (q.incrementLimit) {
+    incrementLimit = parseInt(q.incrementLimit);
+  }
+
+  simulateWork(incrementLimit);
+
+  context.res = {
+    status: 200,
+    body: {
+      RequestID: context.invocationId,
+      TimestampChain: [Date.now().toString()],
+    }
+  };
+};
+
+const simulateWork = (incrementLimit) => {
+  for (let i = 0; i < incrementLimit; i++) { }
+};
+
+module.exports = handler


### PR DESCRIPTION
This PR adds the nodejs18 runtime for Azure Functions.

## Changes
- Add `hellonode` raw-code for Azure
- Add `hellonode.json` experiment JSON file
- Update `builder.go` to support `nodejs18` keyword