### PR TITLE
Reduce burst count for Azure experiments

### DIFF
--- a/continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-100-aws.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-100-aws.json
@@ -8,7 +8,7 @@
       "Handler": "main.lambda_handler",
       "PackageType": "Zip",
       "PackagePattern": "main.py",
-      "Bursts": 1000,
+      "Bursts": 500,
       "BurstSizes": [
         1
       ],

--- a/continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-100-azure.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-100-azure.json
@@ -8,7 +8,7 @@
       "Handler": "main.main",
       "PackageType": "Zip",
       "PackagePattern": "main.py",
-      "Bursts": 1000,
+      "Bursts": 500,
       "BurstSizes": [
         1
       ],

--- a/continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-100-gcr.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-100-gcr.json
@@ -8,7 +8,7 @@
 	  "Handler": "Dockerfile",
 	  "PackageType": "Container",
 	  "PackagePattern": "lambda_function.py",
-      "Bursts": 1000,
+      "Bursts": 500,
       "BurstSizes": [
         1
       ],

--- a/continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-50-aws.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-50-aws.json
@@ -8,7 +8,7 @@
       "Handler": "main.lambda_handler",
       "PackageType": "Zip",
       "PackagePattern": "main.py",
-      "Bursts": 1000,
+      "Bursts": 500,
       "BurstSizes": [
         1
       ],

--- a/continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-50-azure.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-50-azure.json
@@ -8,7 +8,7 @@
       "Handler": "main.main",
       "PackageType": "Zip",
       "PackagePattern": "main.py",
-      "Bursts": 1000,
+      "Bursts": 500,
       "BurstSizes": [
         1
       ],

--- a/continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-50-gcr.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-50-gcr.json
@@ -8,7 +8,7 @@
 	  "Handler": "Dockerfile",
 	  "PackageType": "Container",
 	  "PackagePattern": "lambda_function.py",
-      "Bursts": 1000,
+      "Bursts": 500,
       "BurstSizes": [
         1
       ],

--- a/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/azure/cold-hellonode-zip-azure.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/azure/cold-hellonode-zip-azure.json
@@ -9,7 +9,7 @@
       "Handler": "index.handler",
       "PackageType": "Zip",
       "PackagePattern": "index.js",
-      "Bursts": 1000,
+      "Bursts": 500,
       "BurstSizes": [
         1
       ],

--- a/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/azure/cold-hellopy-zip-azure.json
+++ b/continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/azure/cold-hellopy-zip-azure.json
@@ -9,7 +9,7 @@
       "Handler": "main.main",
       "PackageType": "Zip",
       "PackagePattern": "main.py",
-      "Bursts": 1000,
+      "Bursts": 500,
       "BurstSizes": [
         1
       ],


### PR DESCRIPTION
This PR reduces the burst count for Azure experiments in continuous benchmarking as Azure experiments are taking too long to complete and risk rolling over the results to the next day.

## Changes
- Reduce burst count from 1000 to 500 for Azure image size and runtime experiments