### PR TITLE
Bump runtime action step verisons

### DIFF
--- a/.github/workflows/continuous-benchmarking-runtimes.yml
+++ b/.github/workflows/continuous-benchmarking-runtimes.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Set up Go 1.21
         if: ${{ matrix.runtime == 'go'}}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.21
 
@@ -183,7 +183,7 @@ jobs:
 
       - name: Set up Go 1.21
         if: ${{ matrix.runtime == 'go'}}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.21
 
@@ -296,13 +296,8 @@ jobs:
         with:
           ref: continuous-benchmarking
 
-      - name: Set up Node.js 16.16.0
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
-
       - name: Download client artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: STeLLAR-build
 


### PR DESCRIPTION
This PR bumps the versions of certain steps to the latest version in the yml file for runtime experiments.

## Changes
- Bump go setup step to v3
- Bump download artifact step to v3
- Remove Azure Node.js setup step