### PR TITLE
remove Cloudflare VM cleanup from image size and runtime experiments

### DIFF
--- a/.github/workflows/continuous-benchmarking-image-size.yml
+++ b/.github/workflows/continuous-benchmarking-image-size.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        runner: [ gcr, aws, azure, cloudflare ]
+        runner: [ gcr, aws, azure ]
     env:
       working-directory: ./src
     steps:

--- a/.github/workflows/continuous-benchmarking-runtimes.yml
+++ b/.github/workflows/continuous-benchmarking-runtimes.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        runner: [ gcr, aws, azure, cloudflare ]
+        runner: [ gcr, aws, azure ]
     env:
       working-directory: ./src
     steps:


### PR DESCRIPTION
This PR removes cleanup of Cloudflare VM from image size and runtime experiments, as Cloudflare does not have any image size/runtime experiments.