### PR TITLE
increase job timeouts for scheduled experiments

### DIFF
--- a/.github/workflows/continuous-benchmarking-baseline.yml
+++ b/.github/workflows/continuous-benchmarking-baseline.yml
@@ -77,7 +77,7 @@ jobs:
     name: AWS warm baseline experiment
     needs: build_client
     runs-on: [ self-hosted, aws ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     env:
       working-directory: src
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
@@ -173,7 +173,7 @@ jobs:
     name: GCR warm baseline experiment
     needs: build_client
     runs-on: [ self-hosted, gcr ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     env:
       working-directory: src
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -267,7 +267,7 @@ jobs:
     name: Cloudflare warm baseline experiment
     needs: build_client
     runs-on: [ self-hosted, cloudflare ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     env:
       working-directory: src
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -349,7 +349,7 @@ jobs:
     name: Azure warm baseline experiment
     needs: build_client
     runs-on: [ self-hosted, azure ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     env:
       working-directory: src
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -440,7 +440,7 @@ jobs:
     name: AWS cold baseline experiment
     needs: build_client
     runs-on: [ self-hosted, aws ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     env:
       working-directory: src
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
@@ -535,7 +535,7 @@ jobs:
     name: GCR cold baseline experiment
     needs: build_client
     runs-on: [ self-hosted, gcr ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     env:
       working-directory: src
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -629,7 +629,7 @@ jobs:
     name: Cloudflare cold baseline experiment
     needs: build_client
     runs-on: [ self-hosted, cloudflare ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     env:
       working-directory: src
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -711,7 +711,7 @@ jobs:
     name: Azure cold baseline experiment
     needs: build_client
     runs-on: [ self-hosted, azure ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     env:
       working-directory: src
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/continuous-benchmarking-image-size.yml
+++ b/.github/workflows/continuous-benchmarking-image-size.yml
@@ -56,7 +56,7 @@ jobs:
     name: AWS 50MB image size experiment
     needs: build_client
     runs-on: [ self-hosted, aws ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     env:
       working-directory: src
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
@@ -151,7 +151,7 @@ jobs:
     name: AWS 100MB image size experiment
     needs: build_client
     runs-on: [ self-hosted, aws ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     env:
       working-directory: src
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
@@ -246,7 +246,7 @@ jobs:
     name: Azure 50MB image size experiment
     needs: build_client
     runs-on: [ self-hosted, azure ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     env:
       working-directory: src
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -337,7 +337,7 @@ jobs:
     name: Azure 100MB image size experiment
     needs: build_client
     runs-on: [ self-hosted, azure ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     env:
       working-directory: src
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -428,7 +428,7 @@ jobs:
     name: GCR 50MB image size experiment
     needs: build_client
     runs-on: [ self-hosted, gcr ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     env:
       working-directory: src
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -528,7 +528,7 @@ jobs:
     name: GCR 100MB image size experiment
     needs: build_client
     runs-on: [ self-hosted, gcr ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     env:
       working-directory: src
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/continuous-benchmarking-runtimes.yml
+++ b/.github/workflows/continuous-benchmarking-runtimes.yml
@@ -56,7 +56,7 @@ jobs:
     name: AWS Cold Runtime Experiments
     needs: build_client
     runs-on: [ self-hosted, aws ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     strategy:
       matrix:
         runtime:
@@ -177,7 +177,7 @@ jobs:
     name: GCR Cold Runtime Experiments
     needs: build_client
     runs-on: [ self-hosted, gcr ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     strategy:
       matrix:
         runtime:
@@ -302,7 +302,7 @@ jobs:
     name: Azure Cold Runtime Experiments
     needs: build_client
     runs-on: [ self-hosted, azure ]
-    timeout-minutes: 600
+    timeout-minutes: 1200
     strategy:
       matrix:
         runtime:


### PR DESCRIPTION
This PR increases the timeout duration of jobs from 10 hours to 20 hours. This might be necessary due to the newly implemented retry mechanism in place.

## Changes
- Increase timeout minutes of scheduled experiments from 600 minutes to 1200 minutes