### PR TITLE
add azure-cleanup.yml for scheduled Azure cleanups

### DIFF
--- a/.github/workflows/azure-cleanup.yml
+++ b/.github/workflows/azure-cleanup.yml
@@ -1,0 +1,43 @@
+# MIT License
+#
+# Copyright (c) 2023 Min Kabar Kyaw
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: Azure Resource Group Cleanup
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "55 23 * * *"
+
+jobs:
+  clean_up:
+    name: Clean up Azure Resource Groups
+    steps:
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Azure CLI Cleanup
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az group list --query "[?contains(name, 'sls-wus-dev')].name" -o tsv | xargs -P 10 -n1 az group delete --yes --name


### PR DESCRIPTION
This PR schedules Azure resource group cleanups every day 5 minutes before scheduled experiments start. This ensures any stale resource groups from any previous failures do not hog up the resource group quota.

## Changes
- Add azure-cleanup.yml