### PR TITLE
add gcr-cleanup.yml for scheduled GCR cleanups

### DIFF
--- a/.github/workflows/azure-cleanup.yml
+++ b/.github/workflows/azure-cleanup.yml
@@ -30,6 +30,7 @@ on:
 jobs:
   clean_up:
     name: Clean up Azure Resource Groups
+    runs-on: ubuntu-latest
     steps:
       - name: Azure Login
         uses: azure/login@v1

--- a/.github/workflows/gcr-cleanup.yml
+++ b/.github/workflows/gcr-cleanup.yml
@@ -1,0 +1,46 @@
+# MIT License
+#
+# Copyright (c) 2023 Min Kabar Kyaw
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: GCR Services Cleanup
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "55 23 * * *"
+
+jobs:
+  clean_up:
+    name: Clean up GCR Services
+    steps:
+      - id: auth
+        name: Configure GCR credentials
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCR_CREDENTIALS }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          version: ">= 363.0.0"
+
+      - name: gcloud CLI Cleanup
+        run: gcloud run services list --format="table(name)" | xargs -P 10 -n1 gcloud run services delete --region us-west1 --quiet

--- a/.github/workflows/gcr-cleanup.yml
+++ b/.github/workflows/gcr-cleanup.yml
@@ -30,6 +30,7 @@ on:
 jobs:
   clean_up:
     name: Clean up GCR Services
+    runs-on: ubuntu-latest
     steps:
       - id: auth
         name: Configure GCR credentials
@@ -43,4 +44,4 @@ jobs:
           version: ">= 363.0.0"
 
       - name: gcloud CLI Cleanup
-        run: gcloud run services list --format="table(name)" | xargs -P 10 -n1 gcloud run services delete --region us-west1 --quiet
+        run: gcloud run services list --format="table[no-heading](name)" | xargs -P 10 -n1 gcloud run services delete --region us-west1 --quiet


### PR DESCRIPTION
This PR schedules GCR service cleanups every day 5 minutes before scheduled experiments start. This ensures any stale services from any previous failures do not hog up any service limit quota.

## Changes
- Add gcr-cleanup.yml
- Bugfix: Add omitted `runs-on` value in workflow file for `azure-cleanup.yml`