### PR TITLE
remove Node setup from GCR jobs

### DIFF
--- a/.github/workflows/continuous-benchmarking-image-size.yml
+++ b/.github/workflows/continuous-benchmarking-image-size.yml
@@ -451,11 +451,6 @@ jobs:
         with:
           version: ">= 363.0.0"
 
-      - name: Set up Node 16.16.0
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
-
       - name: Download client artifact
         uses: actions/download-artifact@v3
         with:
@@ -550,11 +545,6 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
         with:
           version: ">= 363.0.0"
-
-      - name: Set up Node 16.16.0
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
 
       - name: Download client artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/continuous-benchmarking-runtimes.yml
+++ b/.github/workflows/continuous-benchmarking-runtimes.yml
@@ -197,11 +197,6 @@ jobs:
         with:
           ref: continuous-benchmarking
 
-      - name: Set up Node.js 16.16.0
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
-
       - name: Set up Go 1.21
         if: ${{ matrix.runtime == 'go'}}
         uses: actions/setup-go@v3


### PR DESCRIPTION
This PR removes the Node.js 16 setup from GCR workflow jobs as it is not necessary for GCR experiments. This is to prevent bloating of the GCR VMs as well.