### PR TITLE
Add Runtime experiment job completion/failure Slack notification

### DIFF
--- a/.github/workflows/continuous-benchmarking-notifications.yml
+++ b/.github/workflows/continuous-benchmarking-notifications.yml
@@ -2,7 +2,7 @@ name: Continuous benchmarking - Send notifications
 
 on:
   workflow_run:
-    workflows: [ Continuous benchmarking - Baseline experiments, Continuous benchmarking - Image size experiments ]
+    workflows: [ Continuous benchmarking - Baseline experiments, Continuous benchmarking - Image size experiments, Continuous benchmarking - Runtime experiments ]
     types: [completed]
 
 jobs:


### PR DESCRIPTION
This PR adds a notification via Slack for completion/failure of Runtime experiments in continuous-benchmarking. Notifications for individual failures already exist, but this notification is for success/failure of the job overall.

## Changes
- Add `Continuous benchmarking - Runtime experiments` to `.github/workflows/continuous-benchmarking-notifications.yml`