### PR TITLE
fix: use `large` self-hosted runner for Azure 100MB experiments

### DIFF
--- a/.github/workflows/continuous-benchmarking-image-size.yml
+++ b/.github/workflows/continuous-benchmarking-image-size.yml
@@ -336,7 +336,7 @@ jobs:
   cold-image-size-100-azure:
     name: Azure 100MB image size experiment
     needs: build_client
-    runs-on: [ self-hosted, azure ]
+    runs-on: [ self-hosted, azure, large ]
     timeout-minutes: 1200
     env:
       working-directory: src


### PR DESCRIPTION
This PR resolves an issue that affected only Azure 100MB image size experiments. There were some instances where the self-hosted runner runs out of memory. An Azure VM with 2GB of RAM with the `large` tag should be used for such experiments instead.