### PR TITLE
add `hellopy-read-random` raw-code

### DIFF
--- a/src/setup/deployment/raw-code/serverless/aws/hellopy-read-random/main.py
+++ b/src/setup/deployment/raw-code/serverless/aws/hellopy-read-random/main.py
@@ -1,0 +1,50 @@
+import json
+import os
+import time
+import random
+
+
+def lambda_handler(request, context):
+    incr_limit = 0
+
+    if 'queryStringParameters' in request and 'IncrementLimit' in request['queryStringParameters']:
+        incr_limit = int(request['queryStringParameters'].get('IncrementLimit', 0))
+    elif 'body' in request and json.loads(request['body'])['IncrementLimit']:
+        incr_limit = int(json.loads(request['body'])['IncrementLimit'])
+
+    simulate_work(incr_limit)
+    read_filler_file('./filler.file')
+
+    json_region = os.environ.get('AWS_REGION', 'Unknown')
+
+    response = {
+        "statusCode": 200,
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": json.dumps({
+            "Region ": json_region,
+            "RequestID": context.aws_request_id,
+            "TimestampChain": [str(time.time_ns())]
+        }, indent=4)
+    }
+
+    return response
+
+
+def simulate_work(increment):
+    # MAXNUM = 6103705
+    num = 0
+    while num < increment:
+        num += 1
+
+
+def read_filler_file(path: str) -> None:
+    file_size = os.stat(path).st_size
+    number_of_pages = file_size // 4096
+    with open(path, 'rb') as f:
+        for _ in range(100):
+            page_number = random.randrange(0, number_of_pages)
+            page_offset = page_number * 4096
+            f.seek(page_offset)
+            f.read(1)

--- a/src/setup/deployment/raw-code/serverless/azure/hellopy-read-random/main.py
+++ b/src/setup/deployment/raw-code/serverless/azure/hellopy-read-random/main.py
@@ -1,0 +1,52 @@
+import json
+import os
+import time
+import random
+
+import azure.functions as func
+
+
+def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    incr_limit = int(req.params.get('IncrementLimit')) if req.params.get('IncrementLimit') else None
+    if not incr_limit:
+        try:
+            req_body = req.get_json()
+        except ValueError:
+            incr_limit = 0
+            pass
+        else:
+            incr_limit = int(req_body.get('IncrementLimit')) if req_body.get('IncrementLimit') else 0
+    else:
+        incr_limit = 0
+
+    simulate_work(incr_limit)
+    read_filler_file(f"{context.function_directory}/../filler.file")
+
+    return func.HttpResponse(
+        body=json.dumps({
+            "RequestID": context.invocation_id,
+            "TimestampChain": [str(time.time_ns())]
+        }, indent=4),
+        status_code=200,
+        headers={
+            "Content-Type": "application/json"
+        }
+    )
+
+
+def simulate_work(increment):
+    # MAXNUM = 6103705
+    num = 0
+    while num < increment:
+        num += 1
+
+
+def read_filler_file(path: str) -> None:
+    file_size = os.stat(path).st_size
+    number_of_pages = file_size // 4096
+    with open(path, 'rb') as f:
+        for _ in range(100):
+            page_number = random.randrange(0, number_of_pages)
+            page_offset = page_number * 4096
+            f.seek(page_offset)
+            f.read(1)

--- a/src/setup/deployment/raw-code/serverless/gcr/hellopy-read-random/Dockerfile
+++ b/src/setup/deployment/raw-code/serverless/gcr/hellopy-read-random/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.7-alpine
+
+RUN pip install Flask gunicorn
+
+WORKDIR /app
+COPY . .
+
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 app:app

--- a/src/setup/deployment/raw-code/serverless/gcr/hellopy-read-random/app.py
+++ b/src/setup/deployment/raw-code/serverless/gcr/hellopy-read-random/app.py
@@ -1,0 +1,51 @@
+import json
+import os
+import time
+import random
+from flask import Flask, request
+
+app = Flask(__name__)
+
+
+@app.route('/')
+def hello_world():
+    incr_limit = 0
+    if request.args and 'incrementLimit' in request.args:
+        incr_limit = request.args.get('incrementLimit')
+
+    read_filler_file("./filler.file")
+    simulate_work(incr_limit)
+
+    response = {
+        "statusCode": 200,
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": {
+            "RequestID": "gcr-does-not-specify",
+            "TimestampChain": [str(time.time_ns())],
+        }
+    }
+
+    return json.dumps(response, indent=4)
+
+
+def simulate_work(incr):
+    num = 0
+    while num < incr:
+        num += 1
+
+
+def read_filler_file(path: str) -> None:
+    file_size = os.stat(path).st_size
+    number_of_pages = file_size // 4096
+    with open(path, 'rb') as f:
+        for _ in range(100):
+            page_number = random.randrange(0, number_of_pages)
+            page_offset = page_number * 4096
+            f.seek(page_offset)
+            f.read(1)
+
+
+if __name__ == "__main__":
+    app.run(debug=True, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))


### PR DESCRIPTION
This PR adds the `hellopy-read-random` raw-code for the cloud providers AWS, Azure and GCR. The `hellopy-read-random` raw-code reads one byte each in 100 randomly chosen pages (of page size 4096 bytes).