### PR TITLE
fix: Add zero'ed data insertion upon experiment failure

### DIFF
--- a/.github/workflows/continuous-benchmarking-baseline.yml
+++ b/.github/workflows/continuous-benchmarking-baseline.yml
@@ -123,6 +123,13 @@ jobs:
           name: warm-baseline-aws
           path: ${{ env.working-directory }}/latency-samples
 
+      - name: Add zero'ed data (Failed experiment)
+        if: ${{ failure() }}
+        env: 
+          DATA_INSERT_URL: ${{ secrets.DATA_INSERT_URL}}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"warm-baseline-aws","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"aws"}' $DATA_INSERT_URL
+
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.24.0
@@ -217,6 +224,13 @@ jobs:
           name: warm-baseline-gcr
           path: ${{ env.working-directory }}/latency-samples
 
+      - name: Add zero'ed data (Failed experiment)
+        if: ${{ failure() }}
+        env: 
+          DATA_INSERT_URL: ${{ secrets.DATA_INSERT_URL}}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"warm-baseline-gcr","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"gcr"}' $DATA_INSERT_URL
+
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.24.0
@@ -298,6 +312,13 @@ jobs:
         with:
           name: warm-baseline-cloudflare
           path: ${{ env.working-directory }}/latency-samples
+
+      - name: Add zero'ed data (Failed experiment)
+        if: ${{ failure() }}
+        env: 
+          DATA_INSERT_URL: ${{ secrets.DATA_INSERT_URL}}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"warm-baseline-cloudflare","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"cloudflare"}' $DATA_INSERT_URL
 
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}
@@ -389,6 +410,13 @@ jobs:
         with:
           name: warm-baseline-azure
           path: ${{ env.working-directory }}/latency-samples
+
+      - name: Add zero'ed data (Failed experiment)
+        if: ${{ failure() }}
+        env: 
+          DATA_INSERT_URL: ${{ secrets.DATA_INSERT_URL}}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"warm-baseline-azure","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"azure"}' $DATA_INSERT_URL
 
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}
@@ -485,6 +513,13 @@ jobs:
           name: cold-baseline-aws
           path: ${{ env.working-directory }}/latency-samples
 
+      - name: Add zero'ed data (Failed experiment)
+        if: ${{ failure() }}
+        env: 
+          DATA_INSERT_URL: ${{ secrets.DATA_INSERT_URL}}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"cold-baseline-aws","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"aws"}' $DATA_INSERT_URL
+
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.24.0
@@ -579,6 +614,13 @@ jobs:
           name: cold-baseline-gcr
           path: ${{ env.working-directory }}/latency-samples
 
+      - name: Add zero'ed data (Failed experiment)
+        if: ${{ failure() }}
+        env: 
+          DATA_INSERT_URL: ${{ secrets.DATA_INSERT_URL}}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"cold-baseline-gcr","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"gcr"}' $DATA_INSERT_URL
+
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.24.0
@@ -660,6 +702,13 @@ jobs:
         with:
           name: cold-baseline-cloudflare
           path: ${{ env.working-directory }}/latency-samples
+
+      - name: Add zero'ed data (Failed experiment)
+        if: ${{ failure() }}
+        env: 
+          DATA_INSERT_URL: ${{ secrets.DATA_INSERT_URL}}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"cold-baseline-cloudflare","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"cloudflare"}' $DATA_INSERT_URL
 
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}
@@ -751,6 +800,13 @@ jobs:
         with:
           name: cold-baseline-azure
           path: ${{ env.working-directory }}/latency-samples
+
+      - name: Add zero'ed data (Failed experiment)
+        if: ${{ failure() }}
+        env: 
+          DATA_INSERT_URL: ${{ secrets.DATA_INSERT_URL}}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"cold-baseline-azure","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"azure"}' $DATA_INSERT_URL
 
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}

--- a/.github/workflows/continuous-benchmarking-image-size.yml
+++ b/.github/workflows/continuous-benchmarking-image-size.yml
@@ -101,6 +101,13 @@ jobs:
           name: cold-image-size-50-aws
           path: ${{ env.working-directory }}/latency-samples
 
+      - name: Add zero'ed data (Failed experiment)
+        if: ${{ failure() }}
+        env: 
+          DATA_INSERT_URL: ${{ secrets.DATA_INSERT_URL}}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"cold-image-size-50-aws","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"aws"}' $DATA_INSERT_URL
+
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.24.0
@@ -196,6 +203,13 @@ jobs:
           name: cold-image-size-100-aws
           path: ${{ env.working-directory }}/latency-samples
 
+      - name: Add zero'ed data (Failed experiment)
+        if: ${{ failure() }}
+        env: 
+          DATA_INSERT_URL: ${{ secrets.DATA_INSERT_URL}}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"cold-image-size-100-aws","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"aws"}' $DATA_INSERT_URL
+
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.24.0
@@ -287,6 +301,13 @@ jobs:
           name: cold-image-size-50-azure
           path: ${{ env.working-directory }}/latency-samples
 
+      - name: Add zero'ed data (Failed experiment)
+        if: ${{ failure() }}
+        env: 
+          DATA_INSERT_URL: ${{ secrets.DATA_INSERT_URL}}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"cold-image-size-50-azure","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"azure"}' $DATA_INSERT_URL
+
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.24.0
@@ -377,6 +398,13 @@ jobs:
         with:
           name: cold-image-size-100-azure
           path: ${{ env.working-directory }}/latency-samples
+
+      - name: Add zero'ed data (Failed experiment)
+        if: ${{ failure() }}
+        env: 
+          DATA_INSERT_URL: ${{ secrets.DATA_INSERT_URL}}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"cold-image-size-100-azure","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"azure"}' $DATA_INSERT_URL
 
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}
@@ -473,6 +501,13 @@ jobs:
           name: cold-image-size-50-gcr
           path: ${{ env.working-directory }}/latency-samples
 
+      - name: Add zero'ed data (Failed experiment)
+        if: ${{ failure() }}
+        env: 
+          DATA_INSERT_URL: ${{ secrets.DATA_INSERT_URL}}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"cold-image-size-50-gcr","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"gcr"}' $DATA_INSERT_URL
+
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.24.0
@@ -567,6 +602,13 @@ jobs:
         with:
           name: cold-image-size-100-gcr
           path: ${{ env.working-directory }}/latency-samples
+
+      - name: Add zero'ed data (Failed experiment)
+        if: ${{ failure() }}
+        env: 
+          DATA_INSERT_URL: ${{ secrets.DATA_INSERT_URL}}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"cold-image-size-100-gcr","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"gcr"}' $DATA_INSERT_URL
 
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}

--- a/.github/workflows/continuous-benchmarking-runtimes.yml
+++ b/.github/workflows/continuous-benchmarking-runtimes.yml
@@ -124,8 +124,16 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: cold-hello${{ matrix.runtime }}-aws-zip
+          name: cold-hello${{ matrix.runtime }}-zip-aws
           path: ${{ env.working-directory }}/latency-samples-aws
+
+      - name: Add zero'ed data (Failed experiment)
+        env:
+          name: cold-hello${{ matrix.runtime }}-zip-aws
+          DATA_INSERT_URL: ${{ secrets.DATA_INSERT_URL}}
+        if: ${{ failure() }}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"'$name'","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"aws"}' $DATA_INSERT_URL
 
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}
@@ -247,6 +255,13 @@ jobs:
           name: cold-hello${{ matrix.runtime }}-img-gcr
           path: ${{ env.working-directory }}/latency-samples-gcr
 
+      - name: Add zero'ed data (Failed experiment)
+        env:
+          name: cold-hello${{ matrix.runtime }}-img-gcr
+        if: ${{ failure() }}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"'$name'","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"gcr"}' $DATA_INSERT_URL
+
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.24.0
@@ -338,6 +353,13 @@ jobs:
         with:
           name: cold-hello${{ matrix.runtime }}-zip-azure
           path: ${{env.working-directory}}/latency-samples-azure
+
+      - name: Add zero'ed data (Failed experiment)
+        env:
+          name: cold-hello${{ matrix.runtime }}-zip-azure
+        if: ${{ failure() }}
+        run: |
+          curl -XPOST -H "Content-type: application/json" -d '{"experiment_type":"'$name'","date":"'$(date +%F)'","min":"0","max":"0","median":"0","tail_latency":"0","first_quartile":"0","third_quartile":"0","standard_deviation":"0","payload_size":"0","burst_size":"0","IATType":"0","count":"0","provider":"azure"}' $DATA_INSERT_URL
 
       - name: Send Slack message using Incoming Webhooks
         if: ${{ failure() }}


### PR DESCRIPTION
When all retries for a scheduled experiment is exhausted, this change inserts an entry into DynamoDB for that particular date and experiment with all entries zero'ed out. This prevents any data discontinuity on the frontend.

## Changes
- Update workflow files to perform zero'ed data insertion upon failure