### PR TITLE
feat: Add support for GCR startup CPU boost

### DIFF
--- a/src/setup/extract-configuration.go
+++ b/src/setup/extract-configuration.go
@@ -64,6 +64,7 @@ type SubExperiment struct {
 	Handler                 string   `json:"Handler"`
 	Runtime                 string   `json:"Runtime"`
 	SnapStartEnabled        bool     `json:"SnapStartEnabled"`
+	CPUBoostEnabled         bool     `json:"CPUBoostEnabled"`
 	PackagePattern          string   `json:"PackagePattern"`
 	// All of the below are computed after reading the configuration
 	BusySpinIncrements []int64 `json:"BusySpinIncrements"`

--- a/src/setup/integration-test/serverless-config_test.go
+++ b/src/setup/integration-test/serverless-config_test.go
@@ -45,6 +45,29 @@ func TestDeployAndRemoveServiceGCR(t *testing.T) {
 	assert.True(strings.Contains(deleteMsg, "Deleted service [abc12-hellopytest-0-0]"))
 }
 
+func TestDeployAndRemoveServiceGCRCPUBoost(t *testing.T) {
+	assert := require.New(t)
+	s := &setup.Serverless{
+		Service:          "STeLLAR",
+		FrameworkVersion: "3",
+		Provider: setup.Provider{
+			Name:    "gcr",
+			Runtime: "python3.9",
+			Region:  "us-west1",
+		},
+	}
+
+	subex := &setup.SubExperiment{
+		Title:           "cpuboosttest",
+		Parallelism:     1,
+		CPUBoostEnabled: true,
+	}
+
+	s.DeployGCRContainerService(subex, 0, "def12", "docker.io/kkmin/hellopy", "../deployment/raw-code/serverless/gcr/hellopy/", "us-west1")
+	deleteMsg := setup.RemoveGCRSingleService("def12-cpuboosttest-0-0")
+	assert.True(strings.Contains(deleteMsg, "Deleted service [def12-cpuboosttest-0-0]"))
+}
+
 func TestDeployAndRemoveServiceAzure(t *testing.T) {
 	assert := require.New(t)
 

--- a/src/setup/serverless-config.go
+++ b/src/setup/serverless-config.go
@@ -435,7 +435,13 @@ func (s *Serverless) DeployGCRContainerService(subex *SubExperiment, index int, 
 		name := fmt.Sprintf("%s-%s", randomTag, createName(subex, index, i))
 		providerFunctionNames["gcr"] = append(providerFunctionNames["gcr"], name) // Used for function removal
 
-		gcrDeployCommand := exec.Command("gcloud", "run", "deploy", name, "--image", imageLink, "--allow-unauthenticated", "--region", region)
+		var gcrDeployCommand *exec.Cmd
+		if subex.CPUBoostEnabled {
+			gcrDeployCommand = exec.Command("gcloud", "run", "deploy", name, "--image", imageLink, "--allow-unauthenticated", "--region", region, "--cpu-boost")
+		} else {
+			gcrDeployCommand = exec.Command("gcloud", "run", "deploy", name, "--image", imageLink, "--allow-unauthenticated", "--region", region)
+		}
+
 		deployMessage := util.RunCommandAndLog(gcrDeployCommand)
 		subex.Endpoints = append(subex.Endpoints, EndpointInfo{ID: GetGCREndpointID(deployMessage)})
 		subex.AddRoute("")


### PR DESCRIPTION
This PR adds support for Google Cloud Run's [startup CPU Boost](https://cloud.google.com/blog/products/serverless/announcing-startup-cpu-boost-for-cloud-run--cloud-functions) feature.

## Changes
- Add `CPUBoostEnabled` field to configuration (default: `false`)
- Add integration test for GCR with CPU boost enabled