### PR TITLE
fix: bypass cleanup if not required, adhere to rate-limit

### DIFF
--- a/.github/workflows/azure-cleanup.yml
+++ b/.github/workflows/azure-cleanup.yml
@@ -41,4 +41,4 @@ jobs:
         uses: azure/CLI@v1
         with:
           inlineScript: |
-            az group list --query "[?contains(name, 'sls-wus-dev')].name" -o tsv | xargs -P 10 -n1 az group delete --yes --name
+            az group list --query "[?contains(name, 'sls-wus-dev')].name" -o tsv | xargs -r -P 10 -n1 az group delete --yes --name

--- a/.github/workflows/gcr-cleanup.yml
+++ b/.github/workflows/gcr-cleanup.yml
@@ -44,4 +44,4 @@ jobs:
           version: ">= 363.0.0"
 
       - name: gcloud CLI Cleanup
-        run: gcloud run services list --format="table[no-heading](name)" | xargs -P 10 -n1 gcloud run services delete --region us-west1 --quiet
+        run: gcloud run services list --format="table[no-heading](name)" | xargs -r -P 10 -n1 bash -c 'gcloud run services delete --region us-west1 --quiet "$0"; sleep 10'


### PR DESCRIPTION
This PR modifies the continuous benchmarking cleanup scripts for GCR and Azure so that they do not appear as failures in the pipeline when there are no functions to remove. GCR also enforces a [rate limit on their Cloud Run Admin write request API](https://cloud.google.com/run/quotas) of 60 requests per 60 seconds, which currently results in failures when are more than 60 functions that require deletion.

## Changes
- Add `-r` xargs flag to omit delete command when input args are empty
- Add sleep command to GCR cleanup script to limit deletions to 10 every 10 seconds