### PR TITLE
ci: update workspace cleanup to per experiment basis

### DIFF
--- a/.github/workflows/continuous-benchmarking-baseline.yml
+++ b/.github/workflows/continuous-benchmarking-baseline.yml
@@ -27,20 +27,6 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  clean_up:
-    name: Clean-up workspace
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      matrix:
-        runner: [ gcr, aws, azure, cloudflare ]
-    env:
-      working-directory: ./src
-    steps:
-      - name: "Cleanup build folder"
-        run: |
-          sudo rm -rf ./* || true
-          sudo rm -rf ./.??* || true
-
   build_client:
     name: Build framework
     needs: clean_up
@@ -84,6 +70,11 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
 
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -186,6 +177,11 @@ jobs:
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -286,6 +282,11 @@ jobs:
       working-directory: src
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -379,6 +380,11 @@ jobs:
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -474,6 +480,11 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -576,6 +587,11 @@ jobs:
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -676,6 +692,11 @@ jobs:
       working-directory: src
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -769,6 +790,11 @@ jobs:
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/continuous-benchmarking-image-size.yml
+++ b/.github/workflows/continuous-benchmarking-image-size.yml
@@ -6,20 +6,6 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  clean_up:
-    name: Clean-up workspace
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      matrix:
-        runner: [ gcr, aws, azure ]
-    env:
-      working-directory: ./src
-    steps:
-      - name: "Cleanup build folder"
-        run: |
-          sudo rm -rf ./* || true
-          sudo rm -rf ./.??* || true
-
   build_client:
     name: Build framework
     needs: clean_up
@@ -62,6 +48,11 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -164,6 +155,11 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -269,6 +265,11 @@ jobs:
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -367,6 +368,11 @@ jobs:
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -463,6 +469,11 @@ jobs:
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -565,6 +576,11 @@ jobs:
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/continuous-benchmarking-runtimes.yml
+++ b/.github/workflows/continuous-benchmarking-runtimes.yml
@@ -6,20 +6,6 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  clean_up:
-    name: Clean-up workspace
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      matrix:
-        runner: [ gcr, aws, azure ]
-    env:
-      working-directory: ./src
-    steps:
-      - name: "Cleanup build folder"
-        run: |
-          sudo rm -rf ./* || true
-          sudo rm -rf ./.??* || true
-
   build_client:
     name: Build framework
     needs: clean_up
@@ -71,6 +57,11 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -200,6 +191,11 @@ jobs:
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -327,6 +323,11 @@ jobs:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
     steps:
+      - name: "Cleanup build folder"
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The current cleanup step for self-hosted runners in continuous benchmarking have a couple of issues:

The current pre-experiment workspace cleanup is only done once per experiment workflow (baseline, image, runtime). However, we have multiple runners that can run a single experiment type concurrently, which means that only 1 of them gets to perform the cleanup.

The current setup can also **cause delays when we do not have enough runners for a particular provider's runner**; the current Github Actions setup of Cleanup->Run Experiment steps require runners from all 3 providers to finish the cleanup before experiments commence. If one provider does not have enough runners to complete the cleanup job, the whole workflow will be stuck on the Cleanup step, and this time can be utilized to start running experiments on runners which have actually completed the cleanup.

This PR changes the cleanup step to be run on a **per experiment basis**. Each machine performs cleanup before starting an experiment independently, which ensures that all machines perform the cleanup before experiments and there are no delays waiting for other machines to finish the cleanup process.

## Changes
- Remove `clean_up` job from continuous benchmarking workflows
- Add the cleanup step before experiment starts