### PR TITLE
fix: remove cleanup job dependency in build step

### DIFF
--- a/.github/workflows/continuous-benchmarking-baseline.yml
+++ b/.github/workflows/continuous-benchmarking-baseline.yml
@@ -29,7 +29,6 @@ on:
 jobs:
   build_client:
     name: Build framework
-    needs: clean_up
     runs-on: ubuntu-latest
     env:
       working-directory: ./src

--- a/.github/workflows/continuous-benchmarking-image-size.yml
+++ b/.github/workflows/continuous-benchmarking-image-size.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   build_client:
     name: Build framework
-    needs: clean_up
     runs-on: ubuntu-latest
     env:
       working-directory: ./src

--- a/.github/workflows/continuous-benchmarking-runtimes.yml
+++ b/.github/workflows/continuous-benchmarking-runtimes.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   build_client:
     name: Build framework
-    needs: clean_up
     runs-on: ubuntu-latest
     env:
       working-directory: ./src


### PR DESCRIPTION
This PR removes the need for the `clean_up` step (which has been removed by #392) before building the STeLLAR binary.

Note: I have pushed a temporary branch with this fix to run today's (20240210) experiments as the scheduled ones have failed due to this.

## Changes
- Remove `needs: clean_up` in build step of continuous benchmarking workflow files