### PR TITLE
fix: disable fail-fast for matrix jobs in continuous benchmarking

### DIFF
--- a/.github/workflows/continuous-benchmarking-runtimes.yml
+++ b/.github/workflows/continuous-benchmarking-runtimes.yml
@@ -43,6 +43,7 @@ jobs:
     runs-on: [ self-hosted, aws ]
     timeout-minutes: 1200
     strategy:
+      fail-fast: false
       matrix:
         runtime:
           [
@@ -177,6 +178,7 @@ jobs:
     runs-on: [ self-hosted, gcr ]
     timeout-minutes: 1200
     strategy:
+      fail-fast: false
       matrix:
         runtime:
           [
@@ -309,6 +311,7 @@ jobs:
     runs-on: [ self-hosted, azure ]
     timeout-minutes: 1200
     strategy:
+      fail-fast: false
       matrix:
         runtime:
           [


### PR DESCRIPTION
This PR temporarily resolves issues stemming from #400. Github Action's default behaviour for matrix jobs cancel all jobs within if one of it fails; this cancellation will bypass the zero data insertion mechanism. `fail-fast: false` allows other jobs within the matrix to continue running.

Note: The unit tests in main here are failing due to the deprecation in #400 as well. The currently develop branch (`feature-serverless-framework-deployment`) will replace these old tests once merged.

## Changes
- Add `fail-fast: false` to continuous benchmarking runtime experiments