### PR TITLE
fix: use `provided.al2023` if `go1.x` is specified

### DIFF
--- a/experiments/tests/aws/hellogo.json
+++ b/experiments/tests/aws/hellogo.json
@@ -6,9 +6,8 @@
     {
       "Title": "parallelism1",
       "Function": "hellogo",
-      "Handler": "main",
+      "Handler": "bootstrap",
       "PackageType": "Zip",
-      "PackagePattern": "main.go",
       "Bursts": 2,
       "BurstSizes": [
         2
@@ -21,9 +20,8 @@
     {
       "Title": "parallelism2",
       "Function": "hellogo",
-      "Handler": "main",
+      "Handler": "bootstrap",
       "PackageType": "Zip",
-      "PackagePattern": "main.go",
       "Bursts": 3,
       "BurstSizes": [
         4

--- a/src/setup/building/builder.go
+++ b/src/setup/building/builder.go
@@ -67,9 +67,9 @@ func buildJava(functionName string, functionDir string, artifactDir string) stri
 // buildGolang builds the Golang binary for serverless deployment
 func buildGolang(functionName string, functionDir string, artifactDir string) string {
 	log.Infof("Building Go from the source code at %s directory", functionDir)
-	artifactPath := fmt.Sprintf("%s/main", artifactDir)
-	util.RunCommandAndLog(exec.Command("env", "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0", "go", "build", "-C", functionDir))
-	util.RunCommandAndLog(exec.Command("mv", fmt.Sprintf("%s/main", functionDir), artifactPath))
+	artifactPath := fmt.Sprintf("%s/bootstrap", artifactDir)
+	util.RunCommandAndLog(exec.Command("env", "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0", "go", "build", "-C", functionDir, "-o", "bootstrap"))
+	util.RunCommandAndLog(exec.Command("mv", fmt.Sprintf("%s/bootstrap", functionDir), artifactPath))
 	return artifactPath
 }
 

--- a/src/setup/deployment/packaging/zip.go
+++ b/src/setup/deployment/packaging/zip.go
@@ -121,7 +121,7 @@ func GenerateServerlessZIPArtifacts(experimentID int, provider string, runtime s
 func generateServerlessZIPArtifactsGeneral(experimentID int, provider string, runtime string, functionName string, functionImageSizeMB float64) {
 	defaultBinaryName := map[string]string{
 		"python3.9":  "main.py",
-		"go1.x":      "main",
+		"go1.x":      "bootstrap",
 		"nodejs18.x": "index.js",
 		"ruby3.2":    "function.rb",
 	}

--- a/src/setup/serverless-config.go
+++ b/src/setup/serverless-config.go
@@ -131,25 +131,31 @@ func (s *Serverless) CreateHeaderConfig(config *Configuration, serviceName strin
 	s.Service = serviceName
 	s.FrameworkVersion = "3"
 
+	runtimeValue := config.Runtime
+	if config.Runtime == "go1.x" {
+		log.Warnf("`go1.x` runtime is deprecated. Runtime `provided.al2023` will be used instead...")
+		runtimeValue = "provided.al2023"
+	}
+
 	switch config.Provider {
 	case "azure":
 		s.Provider = Provider{
 			Name:        config.Provider,
-			Runtime:     config.Runtime,
+			Runtime:     runtimeValue,
 			Region:      region,
 			FunctionApp: FunctionApp{ExtensionVersion: "~4"},
 		}
 	case "aliyun":
 		s.Provider = Provider{
 			Name:        config.Provider,
-			Runtime:     config.Runtime,
+			Runtime:     runtimeValue,
 			Region:      region,
 			Credentials: "~/.aliyuncli/credentials",
 		}
 	default:
 		s.Provider = Provider{
 			Name:    config.Provider,
-			Runtime: config.Runtime,
+			Runtime: runtimeValue,
 			Region:  region,
 		}
 	}
@@ -177,9 +183,14 @@ func (s *Serverless) AddFunctionConfigAWS(subex *SubExperiment, index int, rando
 	if s.Functions == nil {
 		s.Functions = make(map[string]*Function)
 	}
+	
 	for i := 0; i < subex.Parallelism; i++ {
 		handler := subex.Handler
 		runtime := subex.Runtime
+		if runtime == "go1.x" {
+			log.Warnf("`go1.x` runtime is deprecated. Using `provided.al2023` runtime instead...")
+			runtime = "provided.al2023"
+		}
 		name := fmt.Sprintf("%s-%s", randomTag, createName(subex, index, i))
 		events := []Event{
 			{


### PR DESCRIPTION
This PR resolves #400 by automatically deploying with the `provided.al2023` runtime if `go1.x` is specified with a warning about the deprecation. 

Note that the handler value for experiment JSON files have also changed accordingly based on AWS's standards: Handler value `main` must now be `bootstrap`, and the compiled Go binary must also be named `bootstrap` to provide a valid entry for AWS Lambda.

## Changes
- Add warning message and change deployment runtime string to `provided.al2023` if `go1.x` is specified in the experiment JSON
- Update `hellogo.json` sample experiment JSON file to adhere to the new runtime (use `bootstrap` handler value instead of `main`)
- Update building module to compile Go binaries as `bootstrap`
- Update zip module zipping path to correctly locate the `bootstrap` binary