### PR TITLE
docs: update wiki page for AWS benchmarking

### DIFF
--- a/docs/wiki/AWS-Benchmarking.md
+++ b/docs/wiki/AWS-Benchmarking.md
@@ -1,34 +1,90 @@
+## Introduction
+
+This guide provides instructions on how to deploy and benchmark AWS Lambda using STeLLAR.
+
 ## Pre-requisites
-1. [Create an AWS account](https://portal.aws.amazon.com/billing/signup#/start), then go to `My security credentials` -> `Access keys (access key ID and secret access key)` -> `Create New Access Key`. Take note of your Access Key ID and Secret Access Key.
-2. Fetch the deployment branch of STeLLAR, containing the binary as well as other useful configuration files.
 
-```git clone --single-branch --branch deployment https://github.com/ease-lab/STeLLAR.git```
-
-3. Perform some basic update operations, as well as install useful tools (tmux).
-```
-cd STeLLAR/scripts && bash setup.sh
-cd aws && bash setup.sh # Note: here please use your AWS Access Key created at step 1
-```
+1. [AWS account](https://portal.aws.amazon.com/billing/signup#/start/email) with
+   active [access keys](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey)
+   and [AWSLambda_FullAccess](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambda_FullAccess.html)
+   permissions.
 
 ## Setup
-1. **Add permissions for the Lambda functions:** IAM console -> Roles -> Create Role -> Lambda -> Select policies `AWSLambdaFullAccess`, `AWSLambdaBasicExecutionRole` (for logging), `AWSLambdaRole` (for triggering other lambdas in a producer-consumer chain scenario) and `AmazonS3FullAccess ` (for inter-function storage transfers using S3) -> Enter name **exactly** as `LambdaProducerConsumer`. Take note of your 12-digit user ARN number: `arn:aws:iam::12-DIGIT-ARN-NUMBER:role/LambdaProducerConsumer`).
-3. **Add permissions for the STeLLAR client:** IAM console -> Users -> Create User. Attach `AWSLambda_FullAccess` and `AmazonS3FullAccess` to this user, and then create and attach another policy, e.g., named `APIGatewayFull`, which has `API Gateway; Full Access; All resources` and `API Gateway V2; Full Access; All resources`.
 
-~3. **Local client authentication:** IAM console -> Users -> Summary -> Security credentials -> Create access key. **Make sure to keep creating keys until there are no forward slashes in them**. Take note of your Access key ID (e.g., `AKIAU4EZSQEM3S42BXY5`) and Secret access key (e.g., `vAbqZTA3MpxctAi4zvS5QW4Qvvhpkg53lALgDUDV`). Configure your local AWS CLI by running `aws configure`, use your Access Key ID and Secret access key. The default region name used in the client is `us-west-1`.~
+To deploy functions and run experiments on AWS Lambda through STeLLAR,
+the [Serverless](https://www.serverless.com/framework/docs) framework must be
+installed.
 
-### To further enable function [deployments via container images](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html#images-create-1):
-1. Create a private Amazon ECR repository with the name `vhive-bench`.
-2. IAM console -> Users. Select your user created in step 2 and attach the `AmazonEC2ContainerRegistryFullAccess` permission policy to it.
+1. Run the setup script to install dependencies required for running STeLLAR (Note: You may need to change permissions
+   of the script to allow execution):
+   ```shell
+   chmod +x ./scripts/setup.sh
+   ./scripts/setup.sh
+    ```
 
-## Benchmarking:
-We have provided ready-made configurations that helped us generate our [published results](https://github.com/ease-lab/STeLLAR/blob/main/docs/STeLLAR_IISWC21.pdf), but you can easily [design your own experiments](https://github.com/ease-lab/STeLLAR/wiki/Customize-Experiments).
+2. Setup the configuration and credential files for your AWS Command Line Interface by following the
+   instructions [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-methods):
+   ```shell
+   aws configure
+   ```
 
-### Inline data transfers:
-```
-sudo ./main -a 12-DIGIT-ARN-NUMBER -o latency-samples -g endpoints -c experiments/data-transfer/inline/aws/quick-warm-IAT10s.json
-```
+In addition, STeLLAR requires two core components to deploy and benchmark serverless functions: The function code and a
+JSON file specifying experiment parameters.
 
-### Storage data transfers:
-```
-sudo ./main -a 12-DIGIT-ARN-NUMBER -o latency-samples -g endpoints -c experiments/data-transfer/storage/
-```
+### Function code
+
+Put your code directory at `src/setup/deployment/raw-code/serverless/aws/<function_code_dir>`.
+
+### Experiment JSON file
+
+The JSON file specifying configurations can be placed at any path. The folder for our examples can be located under
+the `experiments/` folder. For examples of experiment JSON files,
+see [here](https://github.com/vhive-serverless/STeLLAR/blob/main/experiments/tests/aws).
+
+Summary of experiment JSON file values:
+
+| Key                 | Type    | Description                                                                                                                                                                                                                                                                                                |
+|---------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Sequential          | boolean | Specifies whether to run sub-experiments sequentially or in parallel.                                                                                                                                                                                                                                      |
+| Provider            | string  | Specifies the Cloud Provider to deploy the function to. (e.g. `aws`, `azure`, `gcr`, `cloudflare` etc.)                                                                                                                                                                                                    |
+| Runtime             | string  | Specifies the runtime of the function. (e.g. `python3.9`, `nodejs18.x`, `java11` etc.)                                                                                                                                                                                                                     |
+| SubExperiments      | array   | Array of objects specifying specific experiment parameters for each sub-experiment.                                                                                                                                                                                                                        |
+| Title               | string  | Name of the sub-experiment.                                                                                                                                                                                                                                                                                |
+| Function            | string  | Name of the function. This must be the same value as `<function_code_dir>`.                                                                                                                                                                                                                                |
+| Handler             | string  | Entry point of the function. This should follow the format of `<your_file_name_without_extension>.<your_handler_function_name>`.                                                                                                                                                                           |
+| PackageType         | string  | Specifies the type of packaging for function upload. Only `Zip` is currently accepted for STeLLAR benchmarking of AWS.                                                                                                                                                                                     |
+| Bursts              | number  | Specifies the number of bursts to send to the deployed function(s).                                                                                                                                                                                                                                        |
+| BurstSizes          | array   | Specifies the size of each burst when invoking the deployed function(s). STeLLAR iterates and cycles through the array for each burst.                                                                                                                                                                     |
+| DesiredServiceTimes | array   | Specifies the desired service execution time(s) when invoking the deployed function(s). STeLLAR iterates and cycles through the array for each burst. These execution times are achieved by calculating the corresponding busy spin count for the desired time on the **host running the STeLLAR client**. |
+| FunctionImageSizeMB | number  | Specifies the target size of the function to upload.                                                                                                                                                                                                                                                       |
+| Parallelism         | number  | Specifies the number of concurrent endpoints to deploy and benchmark. Useful for obtaining cold-start samples within a shorter period of time.                                                                                                                                                             |
+
+## Benchmarking
+
+1. Compile the STeLLAR binary at the `src` directory:
+   ```sh
+   cd src
+   go build main.go
+   ```
+
+2. Run the compiled binary:
+   ```sh
+   ./main -o <output_folder_path> -c <experiment_json_file_path> -l <log_level>
+   ```
+
+Summary of the flags available:
+
+| Flag | Description                                                                                                                                                                         |
+|------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-o` | Specifies the directory in which to store experiment results. Each experiment creates a folder named after the timestamp when it was created which is stored inside this directory. |
+| `-c` | Specifies the path of the experiment JSON file which is used to run the experiments on.                                                                                             |
+| `-l` | Specifies the log level to print to the console output. Default value is set to `info`. Possible values: `info`, `debug`                                                            |
+
+### Obtaining Results
+
+STeLLAR generates statistics as well as a CDF diagram after the experiments are completed. These results can be found
+under `<output_folder_path/<experiment_timestamp>`. It contains:
+
+- `/<subexperiment_title>/latencies.csv`: All recorded request latencies for individual invocations
+- `/<subexperiment_title>/statistics.csv`: Statistical information such as percentile, standard deviation, etc.
+- `/<subexperiment_title>/empirical_CDF.png`: A CDF diagram of the sample latencies


### PR DESCRIPTION
This PR updates the existing wiki page on Azure benchmarking for https://github.com/vhive-serverless/STeLLAR/issues/301. A preview of this is available [here](https://github.com/vhive-serverless/STeLLAR/blob/ypwong99/update-aws-docs/docs/wiki/AWS-Benchmarking.md).