### PR TITLE
ci: run scheduled experiments weekly

### DIFF
--- a/.github/workflows/continuous-benchmarking-baseline.yml
+++ b/.github/workflows/continuous-benchmarking-baseline.yml
@@ -24,7 +24,7 @@ name: Continuous benchmarking - Baseline experiments
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 1"
 
 jobs:
   build_client:

--- a/.github/workflows/continuous-benchmarking-image-size.yml
+++ b/.github/workflows/continuous-benchmarking-image-size.yml
@@ -3,7 +3,7 @@ name: Continuous benchmarking - Image size experiments
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 12 * * 1"
 
 jobs:
   build_client:
@@ -357,7 +357,7 @@ jobs:
   cold-image-size-100-azure:
     name: Azure 100MB image size experiment
     needs: build_client
-    runs-on: [ self-hosted, azure, large ]
+    runs-on: [ self-hosted, azure ]
     timeout-minutes: 1200
     env:
       working-directory: src

--- a/.github/workflows/continuous-benchmarking-runtimes.yml
+++ b/.github/workflows/continuous-benchmarking-runtimes.yml
@@ -3,7 +3,7 @@ name: Continuous benchmarking - Runtime experiments
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 2"
 
 jobs:
   build_client:


### PR DESCRIPTION
This PR reduces the frequency of continuous benchmarking experiments, to instead run on a weekly basis.
Baseline experiments run every Monday at 12am UTC.
Image size experiments run every Monday at 12pm UTC.
Runtime experiments run every Tuesday at 12am UTC.