### PR TITLE
ci: automatic provisioning and teardown of self-hosted runners on Google Cloud

### DIFF
--- a/.github/workflows/continuous-benchmarking-provisioning.yml
+++ b/.github/workflows/continuous-benchmarking-provisioning.yml
@@ -81,3 +81,50 @@ jobs:
             ./config.sh --url https://github.com/vhive-serverless/STeLLAR --token ${{ steps.get-registration-token.outputs.token }} --name stellar-continuous-azure --labels azure
             tmux new-session -d -s github-actions-runner 'bash ./run.sh'
           "
+  setup-gcr-vm:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        name: Configure GCR credentials
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCR_CREDENTIALS }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          version: ">= 363.0.0"
+
+      - name: Create a registration token for self-hosted runners
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/vhive-serverless/STeLLAR/actions/runners/registration-token \
+          | echo token=$(jq -r .token) > $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOY_SELF_HOSTED_RUNNER_TOKEN }}
+        id: get-registration-token
+
+      - name: Create GCloud Compute Engine VM
+        run: gcloud compute instances create github-actions-runner-gcr --zone=us-west1-a  --image=stellar-continuous-gcr-disk --image-project=stellar-benchmarking --machine-type=e2-small
+
+      - name: Setup self-hosted runner
+        run: |
+          gcloud compute ssh --zone "us-west1-a" "User@github-actions-runner-gcr" --project "stellar-benchmarking" --command '
+            sudo rm -r ./actions-runner &&
+            echo "Installing STeLLAR dependencies" &&
+            curl -o stellar-setup.sh https://raw.githubusercontent.com/vhive-serverless/STeLLAR/main/scripts/setup.sh &&
+            chmod +x stellar-setup.sh &&
+            ./stellar-setup.sh &&
+            echo "Setup self-hosted runner" &&
+            mkdir actions-runner && cd actions-runner &&
+            curl -o actions-runner-linux-x64-2.315.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.315.0/actions-runner-linux-x64-2.315.0.tar.gz &&
+            tar xzf ./actions-runner-linux-x64-2.315.0.tar.gz &&
+            printf "\nstellar-continuous-gcr\ngcr\n" | ./config.sh --url https://github.com/vhive-serverless/STeLLAR --token ${{ steps.get-registration-token.outputs.token }} &&
+            tmux new-session -d -s github-actions-runner-gcr "bash ./run.sh"
+          '

--- a/.github/workflows/continuous-benchmarking-teardown.yml
+++ b/.github/workflows/continuous-benchmarking-teardown.yml
@@ -40,3 +40,44 @@ jobs:
 
       - name: Delete Azure resource group
         run: az group delete --resource-group github-actions-runners --yes
+
+  teardown-gcr-vm:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        name: Configure GCR credentials
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCR_CREDENTIALS }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          version: ">= 363.0.0"
+
+      - name: Get self-hosted runner ID
+        id: get-runner-id
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOY_SELF_HOSTED_RUNNER_TOKEN }}
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/vhive-serverless/STeLLAR/actions/runners \
+          | echo id=$(jq '.runners[] | select(.name == "stellar-continuous-gcr") | .id') > $GITHUB_OUTPUT
+
+      - name: Remove self-hosted runner
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOY_SELF_HOSTED_RUNNER_TOKEN }}
+        run: |
+          gh api \
+            --method DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/vhive-serverless/STeLLAR/actions/runners/${{ steps.get-runner-id.outputs.id }}
+
+      - name: Delete GCloud Compute Engine VM 
+        run: gcloud compute instances delete github-actions-runner-gcr --zone=us-west1-a


### PR DESCRIPTION
This PR adds support for automatic provisioning and teardown of self-hosted runners on Google Cloud (Compute Engine).
The provisioning of VMs and addition of self-hosted runners occur every Sunday at 11pm UTC.
The teardown of VMs and removal of self-hosted runners occur every Wednesday at 12am UTC.