### PR TITLE
fix: update AMI value for EC2 provisioning (Cloudflare)

### DIFF
--- a/.github/workflows/continuous-benchmarking-provisioning.yml
+++ b/.github/workflows/continuous-benchmarking-provisioning.yml
@@ -98,7 +98,7 @@ jobs:
           run: |
             aws ec2 run-instances \
               --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=16}' \
-              --image-id ami-08012c0a9ee8e21c4 \
+              --image-id ami-04a4e0a5175618353 \
               --instance-type t2.micro \
               --key-name stellar-ssh-key \
               --region us-east-2 \


### PR DESCRIPTION
This PR updates the Amazon Machine Image (AMI) value for provisioning EC2 instances for Cloudflare. The previous value failed as it was in a different region; a copy of the image has been created for Cloudflare in `us-east-2`.