### PR TITLE
 fix: add wrangler installation on provisioned EC2 (Cloudflare)

### DIFF
--- a/.github/workflows/continuous-benchmarking-provisioning.yml
+++ b/.github/workflows/continuous-benchmarking-provisioning.yml
@@ -98,7 +98,7 @@ jobs:
           run: |
             aws ec2 run-instances \
               --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=16}' \
-              --image-id ami-08012c0a9ee8e21c4 \
+              --image-id ami-04a4e0a5175618353 \
               --instance-type t2.micro \
               --key-name stellar-ssh-key \
               --region us-east-2 \

--- a/.github/workflows/continuous-benchmarking-provisioning.yml
+++ b/.github/workflows/continuous-benchmarking-provisioning.yml
@@ -134,6 +134,10 @@ jobs:
               chmod +x stellar-setup.sh
               ./stellar-setup.sh
 
+              curl -o cloudflare-setup.sh https://raw.githubusercontent.com/vhive-serverless/STeLLAR/main/scripts/cloudflare/setup.sh
+              chmod +x cloudflare-setup.sh
+              ./cloudflare-setup.sh
+
               echo 'Setup self-hosted runner'
               mkdir actions-runner && cd actions-runner
               curl -o actions-runner-linux-x64-2.315.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.315.0/actions-runner-linux-x64-2.315.0.tar.gz


### PR DESCRIPTION
This PR adds the installation of wrangler via Cloudflare's setup script for provisioned EC2 instances.