### PR TITLE
fix: use fresh Ubuntu 22 image during automatic provisioning of AWS EC2 instances

### DIFF
--- a/.github/workflows/continuous-benchmarking-provisioning.yml
+++ b/.github/workflows/continuous-benchmarking-provisioning.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           aws ec2 run-instances \
             --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=16}' \
-            --image-id ami-08012c0a9ee8e21c4 \
+            --image-id ami-036cafe742923b3d9 \
             --instance-type t2.micro \
             --key-name stellar-ssh-key \
             --region us-west-1 \
@@ -98,7 +98,7 @@ jobs:
           run: |
             aws ec2 run-instances \
               --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=16}' \
-              --image-id ami-04a4e0a5175618353 \
+              --image-id ami-0f30a9c3a48f3fa79 \
               --instance-type t2.micro \
               --key-name stellar-ssh-key \
               --region us-east-2 \

--- a/scripts/cloudflare/setup.sh
+++ b/scripts/cloudflare/setup.sh
@@ -2,4 +2,5 @@
 # Install Wrangler CLI
 npm install -g wrangler --save-dev
 
-wrangler login
+# Login to Wrangler (via web browser)
+# wrangler login


### PR DESCRIPTION
This PR updates the Amazon Machine Image (AMI) value for the automatic provisioning of AWS EC2 instances. The AMI values of `ami-036cafe742923b3d9` and `ami-0f30a9c3a48f3fa79` is for Ubuntu 22 in the `us-west-1` and `us-east-2` region respectively.

It also makes the `wrangler login` step in our `scripts/cloudflare/setup.sh` file optional, as `wrangler login` requires a web browser.