### PR TITLE
ci: update to Node 18

### DIFF
--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -156,14 +156,14 @@ jobs:
           ALIYUN_ACCESS_KEY_ID: ${{ secrets.ALIYUN_ACCESS_KEY_ID }}
           ALIYUN_ACCOUNT_ID: ${{ secrets.ALIYUN_ACCOUNT_ID }}
 
-      - name: Set up Node.js 16.16.0
+      - name: Set up Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16.16.0
+          node-version: 18
 
       - name: Install Serverless framework and related plugins
         # functions-have-names appears to be a dependency of serverless-azure-functions
-        run: npm install -g serverless serverless-azure-functions functions-have-names serverless-aliyun-function-compute
+        run: npm install -g serverless@3.38.0 serverless-azure-functions functions-have-names serverless-aliyun-function-compute
 
       - name: Install Cloudflare Wrangler
         run: npm install -g wrangler
@@ -197,14 +197,14 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Set up Node.js 16.16.0
+      - name: Set up Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16.16.0
+          node-version: 18
 
       - name: Install Serverless framework and related plugins
         # functions-have-names appears to be a dependency of serverless-azure-functions
-        run: npm install -g serverless serverless-azure-functions functions-have-names
+        run: npm install -g serverless@3.38.0 serverless-azure-functions functions-have-names
 
       - name: Download client artifact
         uses: actions/download-artifact@v3
@@ -247,13 +247,13 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
           aws-region: us-west-1
 
-      - name: Set up Node.js 16.16.0
+      - name: Set up Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16.16.0
+          node-version: 18
 
       - name: Install serverless framework
-        run: npm install -g serverless
+        run: npm install -g serverless@3.38.0
 
       - name: Download client artifact
         uses: actions/download-artifact@v3
@@ -297,10 +297,10 @@ jobs:
         with:
           version: ">= 363.0.0"
 
-      - name: Set up Node.js 16.16.0
+      - name: Set up Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16.16.0
+          node-version: 18
 
       - name: Download client artifact
         uses: actions/download-artifact@v3
@@ -340,10 +340,10 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Set up Node.js 16.16.0
+      - name: Set up Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16.16.0
+          node-version: 18
 
       - name: Install Cloudflare Wrangler
         run: npm install -g wrangler

--- a/src/setup/integration-test/azure-integration-test-serverless.yml
+++ b/src/setup/integration-test/azure-integration-test-serverless.yml
@@ -1,4 +1,4 @@
-service: stellar-azure-itgr-test
+service: stellar-azure-integration-test
 
 frameworkVersion: "3"
 


### PR DESCRIPTION
This PR updates our CI pipeline to use Node 18 as scheduled tests failed previously with the following error message: "Your Nodejs version is too old, please upgrade to Node 18 or newer and rerun Serverless".

It also installs the older Serverless Framework V3, as there are breaking changes in Serverless Framework V4, as described in #462.