### PR TITLE
add retry mechanism for aws ec2 instances provisioning

### DIFF
--- a/.github/workflows/continuous-benchmarking-baseline.yml
+++ b/.github/workflows/continuous-benchmarking-baseline.yml
@@ -86,10 +86,17 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
           aws-region: us-west-1
 
-      - name: Set up Node.js 16.16.0
+      - name: Set up Node.js 18
         uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
+        with: 
+          node-version: 18
+          
+      - name: Cleanup serverless folder 
+        run: |
+              rm -rf /home/ubuntu/actions-runner/_work/_tool/node/18.20.4/x64/lib/node_modules/serverless   
+          
+      - name: Install Serverless framework and related plugins
+        run: npm install -g serverless@3.38.0 
 
       - name: Download client artifact
         uses: actions/download-artifact@v3
@@ -290,7 +297,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: continuous-benchmarking
+          
+      - name: Set up Node.js 18
+        uses: actions/setup-node@v3
+        with: 
+          node-version: 18
 
+      - name: Install Cloudflare Wrangler
+        run: npm install -g wrangler
+      
       - name: Download client artifact
         uses: actions/download-artifact@v3
         with:
@@ -388,11 +403,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: continuous-benchmarking
-
-      - name: Set up Node 16.16.0
+          
+      - name: Set up Node.js 18
         uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
+        with: 
+          node-version: 18
+
+      - name: Install Serverless framework and related plugins
+        run: npm install -g serverless@3.38.0 serverless-azure-functions functions-have-names serverless-aliyun-function-compute
 
       - name: Download client artifact
         uses: actions/download-artifact@v3
@@ -496,10 +514,17 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
           aws-region: us-west-1
 
-      - name: Set up Node.js 16.16.0
+      - name: Set up Node.js 18
         uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
+        with: 
+          node-version: 18
+          
+      - name: Cleanup serverless folder 
+        run: |
+              rm -rf /home/ubuntu/actions-runner/_work/_tool/node/18.20.4/x64/lib/node_modules/serverless   
+          
+      - name: Install Serverless framework and related plugins
+        run: npm install -g serverless@3.38.0
 
       - name: Download client artifact
         uses: actions/download-artifact@v3
@@ -700,7 +725,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: continuous-benchmarking
+          
+      - name: Set up Node.js 18
+        uses: actions/setup-node@v3
+        with: 
+          node-version: 18
 
+      - name: Install Cloudflare Wrangler
+        run: npm install -g wrangler
+        
       - name: Download client artifact
         uses: actions/download-artifact@v3
         with:
@@ -799,10 +832,13 @@ jobs:
         with:
           ref: continuous-benchmarking
 
-      - name: Set up Node 16.16.0
+      - name: Set up Node.js 18
         uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
+        with: 
+          node-version: 18
+
+      - name: Install Serverless framework and related plugins
+        run: npm install -g serverless@3.38.0 serverless-azure-functions functions-have-names serverless-aliyun-function-compute
 
       - name: Download client artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/continuous-benchmarking-image-size.yml
+++ b/.github/workflows/continuous-benchmarking-image-size.yml
@@ -64,10 +64,17 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
           aws-region: us-west-1
 
-      - name: Set up Node.js 16.16.0
+      - name: Set up Node.js 18
         uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
+        with: 
+          node-version: 18
+          
+      - name: Cleanup serverless folder 
+        run: |
+              rm -rf /home/ubuntu/actions-runner/_work/_tool/node/18.20.4/x64/lib/node_modules/serverless   
+          
+      - name: Install Serverless framework and related plugins
+        run: npm install -g serverless@3.38.0 
 
       - name: Download client artifact
         uses: actions/download-artifact@v3
@@ -171,11 +178,18 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
           aws-region: us-west-1
 
-      - name: Set up Node.js 16.16.0
+      - name: Set up Node.js 18
         uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
-
+        with: 
+          node-version: 18
+          
+      - name: Cleanup serverless folder 
+        run: |
+              rm -rf /home/ubuntu/actions-runner/_work/_tool/node/18.20.4/x64/lib/node_modules/serverless   
+          
+      - name: Install Serverless framework and related plugins
+        run: npm install -g serverless@3.38.0 
+  
       - name: Download client artifact
         uses: actions/download-artifact@v3
         with:
@@ -274,10 +288,13 @@ jobs:
         with:
           ref: continuous-benchmarking
 
-      - name: Set up Node 16.16.0
+      - name: Set up Node.js 18
         uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
+        with: 
+          node-version: 18
+
+      - name: Install Serverless framework and related plugins
+        run: npm install -g serverless@3.38.0 serverless-azure-functions functions-have-names serverless-aliyun-function-compute
 
       - name: Download client artifact
         uses: actions/download-artifact@v3
@@ -377,10 +394,13 @@ jobs:
         with:
           ref: continuous-benchmarking
 
-      - name: Set up Node 16.16.0
+      - name: Set up Node.js 18
         uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
+        with: 
+          node-version: 18
+
+      - name: Install Serverless framework and related plugins
+        run: npm install -g serverless@3.38.0 serverless-azure-functions functions-have-names serverless-aliyun-function-compute
 
       - name: Download client artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/continuous-benchmarking-provisioning.yml
+++ b/.github/workflows/continuous-benchmarking-provisioning.yml
@@ -59,20 +59,40 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Setup self-hosted runner
-        run: |
-          ssh -o StrictHostKeyChecking=no ubuntu@${{ steps.get-ip.outputs.ip }} "
-            echo 'Installing STeLLAR dependencies'
-            curl -o stellar-setup.sh https://raw.githubusercontent.com/vhive-serverless/STeLLAR/main/scripts/setup.sh
-            chmod +x stellar-setup.sh
-            ./stellar-setup.sh
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOY_SELF_HOSTED_RUNNER_TOKEN }}
+        uses: nick-fields/retry@v2
+        with:
+            timeout_minutes: 30
+            max_attempts: 5
+            retry_wait_seconds: 10
+            command: |
+                # Exit if runner is already set up
+                RUNNER_STATUS=$(gh api -H "Accept: application/vnd.github+json" /repos/vhive-serverless/STeLLAR/actions/runners | grep 'aws')
+                echo "Runner Status: $RUNNER_STATUS"
+                if [ -n "$RUNNER_STATUS" ]; then
+                  echo "Runner with label 'aws' is already set up and running."
+                  exit 0
+                fi
 
-            echo 'Setup self-hosted runner'
-            mkdir actions-runner && cd actions-runner
-            curl -o actions-runner-linux-x64-2.315.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.315.0/actions-runner-linux-x64-2.315.0.tar.gz
-            tar xzf ./actions-runner-linux-x64-2.315.0.tar.gz
-            ./config.sh --url https://github.com/vhive-serverless/STeLLAR --token ${{ steps.get-registration-token.outputs.token }} --name ${{ env.AWS_RUNNER_NAME }} --labels aws
-            tmux new-session -d -s github-actions-runner 'bash ./run.sh'
-          "
+                # Connection status
+                CONNECTION_READY_STATUS=describe_instance=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].{Instance:InstanceId,State:State.Name,PublicIP:PublicIpAddress}' --output table)
+                echo "$CONNECTION_READY_STATUS"
+
+                # Connect via SSH to instance
+                ssh -o StrictHostKeyChecking=no ubuntu@${{ steps.get-ip.outputs.ip }} "
+                  echo 'Installing STeLLAR dependencies'
+                  curl -o stellar-setup.sh https://raw.githubusercontent.com/vhive-serverless/STeLLAR/main/scripts/setup.sh
+                  chmod +x stellar-setup.sh
+                  ./stellar-setup.sh
+      
+                  echo 'Setup self-hosted runner'
+                  mkdir actions-runner && cd actions-runner
+                  curl -o actions-runner-linux-x64-2.315.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.315.0/actions-runner-linux-x64-2.315.0.tar.gz
+                  tar xzf ./actions-runner-linux-x64-2.315.0.tar.gz
+                  ./config.sh --url https://github.com/vhive-serverless/STeLLAR --token ${{ steps.get-registration-token.outputs.token }} --name ${{ env.AWS_RUNNER_NAME }} --labels aws
+                  tmux new-session -d -s github-actions-runner 'bash ./run.sh'
+                "
 
   setup-cloudflare-vm:
       runs-on: ubuntu-latest
@@ -127,24 +147,44 @@ jobs:
             ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
         - name: Setup self-hosted runner
-          run: |
-            ssh -o StrictHostKeyChecking=no ubuntu@${{ steps.get-ip.outputs.ip }} "
-              echo 'Installing STeLLAR dependencies'
-              curl -o stellar-setup.sh https://raw.githubusercontent.com/vhive-serverless/STeLLAR/main/scripts/setup.sh
-              chmod +x stellar-setup.sh
-              ./stellar-setup.sh
+          env:
+              GH_TOKEN: ${{ secrets.DEPLOY_SELF_HOSTED_RUNNER_TOKEN }}
+          with:
+            timeout_minutes: 30
+            max_attempts: 5
+            retry_wait_seconds: 10
+            command: |
+                # "Exit if runner is already set up"
 
-              curl -o cloudflare-setup.sh https://raw.githubusercontent.com/vhive-serverless/STeLLAR/main/scripts/cloudflare/setup.sh
-              chmod +x cloudflare-setup.sh
-              ./cloudflare-setup.sh
+                RUNNER_STATUS=$(gh api -H "Accept: application/vnd.github+json" /repos/vhive-serverless/STeLLAR/actions/runners | grep 'cloudflare')
+                echo "Runner Status: $RUNNER_STATUS"
+                if [ -n "$RUNNER_STATUS" ]; then
+                  echo "Runner with label 'cloudflare' is already set up and running"
+                  exit 0
+                fi
 
-              echo 'Setup self-hosted runner'
-              mkdir actions-runner && cd actions-runner
-              curl -o actions-runner-linux-x64-2.315.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.315.0/actions-runner-linux-x64-2.315.0.tar.gz
-              tar xzf ./actions-runner-linux-x64-2.315.0.tar.gz
-              ./config.sh --url https://github.com/vhive-serverless/STeLLAR --token ${{ steps.get-registration-token.outputs.token }} --name ${{ env.CLOUDFLARE_RUNNER_NAME }} --labels cloudflare
-              tmux new-session -d -s github-actions-runner 'bash ./run.sh'
-            "
+                # connection status
+                CONNECTION_READY_STATUS=describe_instance=$(aws ec2 describe-instances --query 'Reservations[*].Instances[*].{Instance:InstanceId,State:State.Name,,PublicIP:PublicIpAddress}' --output table)
+                echo "$CONNECTION_READY_STATUS"
+
+                # connect via SSH to instance
+                ssh -o StrictHostKeyChecking=no ubuntu@${{ steps.get-ip.outputs.ip }} "
+                  echo 'Installing STeLLAR dependencies'
+                  curl -o stellar-setup.sh https://raw.githubusercontent.com/vhive-serverless/STeLLAR/main/scripts/setup.sh
+                  chmod +x stellar-setup.sh
+                  ./stellar-setup.sh
+
+                  curl -o cloudflare-setup.sh https://raw.githubusercontent.com/vhive-serverless/STeLLAR/main/scripts/cloudflare/setup.sh
+                  chmod +x cloudflare-setup.sh
+                  ./cloudflare-setup.sh
+      
+                  echo 'Setup self-hosted runner'
+                  mkdir actions-runner && cd actions-runner
+                  curl -o actions-runner-linux-x64-2.315.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.315.0/actions-runner-linux-x64-2.315.0.tar.gz
+                  tar xzf ./actions-runner-linux-x64-2.315.0.tar.gz
+                  ./config.sh --url https://github.com/vhive-serverless/STeLLAR --token ${{ steps.get-registration-token.outputs.token }} --name ${{ env.CLOUDFLARE_RUNNER_NAME }} --labels cloudflare
+                  tmux new-session -d -s github-actions-runner 'bash ./run.sh'
+                "
 
   setup-azure-vm:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-benchmarking-runtimes.yml
+++ b/.github/workflows/continuous-benchmarking-runtimes.yml
@@ -67,11 +67,18 @@ jobs:
         with:
           ref: continuous-benchmarking
 
-      - name: Set up Node.js 16.16.0
+      - name: Set up Node.js 18
         uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
-
+        with: 
+          node-version: 18
+          
+      - name: Cleanup serverless folder 
+        run: |
+              rm -rf /home/ubuntu/actions-runner/_work/_tool/node/18.20.4/x64/lib/node_modules/serverless   
+          
+      - name: Install Serverless framework and related plugins
+        run: npm install -g serverless@3.38.0 
+  
       - name: Set up Go 1.21
         if: ${{ matrix.runtime == 'go'}}
         uses: actions/setup-go@v3
@@ -335,6 +342,14 @@ jobs:
         with:
           ref: continuous-benchmarking
 
+      - name: Set up Node.js 18
+        uses: actions/setup-node@v3
+        with: 
+          node-version: 18
+
+      - name: Install Serverless framework and related plugins
+        run: npm install -g serverless@3.38.0 serverless-azure-functions functions-have-names serverless-aliyun-function-compute
+  
       - name: Download client artifact
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
This PR updates the workflow for Provisioning VMs and runners to retry if connection and runner setup on AWS EC2 instances fail for aws and cloudflare jobs, as mentioned in #464.

It also address the issue #463, #466 of continuous benchmarking experiments failing. To resolve, updates are made to the experiments workflow files to install and setup node js 18 and serverless 3.38.0 for aws and azure, and wrangler setup for cloudflare.