### PR TITLE
Update artifact action version

### DIFF
--- a/.github/workflows/continuous-benchmarking-baseline.yml
+++ b/.github/workflows/continuous-benchmarking-baseline.yml
@@ -52,7 +52,7 @@ jobs:
         run: tar -czvf build.tar ./stellar
 
       - name: Upload client artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: STeLLAR-build
           path: ${{ env.working-directory }}/build.tar
@@ -99,7 +99,7 @@ jobs:
         run: npm install -g serverless@3.38.0 
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -115,7 +115,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -a 356764711652 -o latency-samples -c ../continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-aws.json -db -w
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: warm-baseline-aws
           path: ${{ env.working-directory }}/latency-samples
@@ -205,7 +205,7 @@ jobs:
           version: ">= 363.0.0"
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -221,7 +221,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -a 356764711652 -o latency-samples -c ../continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-gcr.json -db -w
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: warm-baseline-gcr
           path: ${{ env.working-directory }}/latency-samples
@@ -307,7 +307,7 @@ jobs:
         run: npm install -g wrangler
       
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -323,7 +323,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -a 356764711652 -o latency-samples -c ../continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-cloudflare.json -db -w
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: warm-baseline-cloudflare
           path: ${{ env.working-directory }}/latency-samples
@@ -413,7 +413,7 @@ jobs:
         run: npm install -g serverless@3.38.0 serverless-azure-functions functions-have-names serverless-aliyun-function-compute
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -429,7 +429,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -c ../continuous-benchmarking/experiments/warm-function-invocations/warm-baseline-azure.json -db -w
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: warm-baseline-azure
           path: ${{ env.working-directory }}/latency-samples
@@ -527,7 +527,7 @@ jobs:
         run: npm install -g serverless@3.38.0
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -543,7 +543,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -a 356764711652 -o latency-samples -c ../continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-aws.json -db
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cold-baseline-aws
           path: ${{ env.working-directory }}/latency-samples
@@ -633,7 +633,7 @@ jobs:
           version: ">= 363.0.0"
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -649,7 +649,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -a 356764711652 -o latency-samples -c ../continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-gcr.json -db
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cold-baseline-gcr
           path: ${{ env.working-directory }}/latency-samples
@@ -735,7 +735,7 @@ jobs:
         run: npm install -g wrangler
         
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -751,7 +751,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -a 356764711652 -o latency-samples -c ../continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-cloudflare.json -db
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cold-baseline-cloudflare
           path: ${{ env.working-directory }}/latency-samples
@@ -841,7 +841,7 @@ jobs:
         run: npm install -g serverless@3.38.0 serverless-azure-functions functions-have-names serverless-aliyun-function-compute
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -857,7 +857,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -c ../continuous-benchmarking/experiments/cold-function-invocations/cold-baseline-azure.json -db -l debug
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cold-baseline-azure
           path: ${{ env.working-directory }}/latency-samples

--- a/.github/workflows/continuous-benchmarking-image-size.yml
+++ b/.github/workflows/continuous-benchmarking-image-size.yml
@@ -31,7 +31,7 @@ jobs:
         run: tar -czvf build.tar ./stellar
 
       - name: Upload client artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: STeLLAR-build
           path: ${{ env.working-directory }}/build.tar
@@ -77,7 +77,7 @@ jobs:
         run: npm install -g serverless@3.38.0 
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -93,7 +93,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -a 356764711652 -o latency-samples -c ../continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-50-aws.json -db
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cold-image-size-50-aws
           path: ${{ env.working-directory }}/latency-samples
@@ -191,7 +191,7 @@ jobs:
         run: npm install -g serverless@3.38.0 
   
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -207,7 +207,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -a 356764711652 -o latency-samples -c ../continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-100-aws.json -db
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cold-image-size-100-aws
           path: ${{ env.working-directory }}/latency-samples
@@ -297,7 +297,7 @@ jobs:
         run: npm install -g serverless@3.38.0 serverless-azure-functions functions-have-names serverless-aliyun-function-compute
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -313,7 +313,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -c ../continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-50-azure.json -db
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cold-image-size-50-azure
           path: ${{ env.working-directory }}/latency-samples
@@ -403,7 +403,7 @@ jobs:
         run: npm install -g serverless@3.38.0 serverless-azure-functions functions-have-names serverless-aliyun-function-compute
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -419,7 +419,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -c ../continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-100-azure.json -db
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cold-image-size-100-azure
           path: ${{ env.working-directory }}/latency-samples
@@ -510,7 +510,7 @@ jobs:
           version: ">= 363.0.0"
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -526,7 +526,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -c ../continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-50-gcr.json -db
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cold-image-size-50-gcr
           path: ${{ env.working-directory }}/latency-samples
@@ -617,7 +617,7 @@ jobs:
           version: ">= 363.0.0"
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -633,7 +633,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -c ../continuous-benchmarking/experiments/cold-function-invocations/image-size/cold-image-size-100-gcr.json -db
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cold-image-size-100-gcr
           path: ${{ env.working-directory }}/latency-samples

--- a/.github/workflows/continuous-benchmarking-runtimes.yml
+++ b/.github/workflows/continuous-benchmarking-runtimes.yml
@@ -31,7 +31,7 @@ jobs:
         run: tar -czvf build.tar ./stellar
 
       - name: Upload client artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: STeLLAR-build
           path: ${{ env.working-directory }}/build.tar
@@ -104,7 +104,7 @@ jobs:
           aws-region: us-west-1
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -120,7 +120,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -o latency-samples-aws -l debug -c ../continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/aws/cold-hello${{ matrix.runtime }}-zip-aws.json -db
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cold-hello${{ matrix.runtime }}-zip-aws
           path: ${{ env.working-directory }}/latency-samples-aws
@@ -238,7 +238,7 @@ jobs:
           version: ">= 363.0.0"
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -254,7 +254,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -o latency-samples-gcr -l debug -c ../continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/gcr/cold-hello${{ matrix.runtime }}-img-gcr.json -db
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cold-hello${{ matrix.runtime }}-img-gcr
           path: ${{ env.working-directory }}/latency-samples-gcr
@@ -351,7 +351,7 @@ jobs:
         run: npm install -g serverless@3.38.0 serverless-azure-functions functions-have-names serverless-aliyun-function-compute
   
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -367,7 +367,7 @@ jobs:
           retry_wait_seconds: 60
           command: cd src && ./stellar -o latency-samples-azure -l debug -c ../continuous-benchmarking/experiments/cold-function-invocations/language-runtime-deployment-method/azure/cold-hello${{matrix.runtime}}-zip-azure.json -db
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cold-hello${{ matrix.runtime }}-zip-azure
           path: ${{env.working-directory}}/latency-samples-azure

--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -48,7 +48,7 @@ jobs:
           tar -czvf build.tar ./main ./setup/deployment/raw-code/functions
 
       - name: Upload client artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: STeLLAR-build
           path: build.tar
@@ -96,7 +96,7 @@ jobs:
           version: ">= 363.0.0"
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -169,7 +169,7 @@ jobs:
         run: npm install -g wrangler
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -207,7 +207,7 @@ jobs:
         run: npm install -g serverless@3.38.0 serverless-azure-functions functions-have-names
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -256,7 +256,7 @@ jobs:
         run: npm install -g serverless@3.38.0
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -303,7 +303,7 @@ jobs:
           node-version: 18
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 
@@ -349,7 +349,7 @@ jobs:
         run: npm install -g wrangler
 
       - name: Download client artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: STeLLAR-build
 


### PR DESCRIPTION
- Update the artifact upload action version (v3 --> v4) to ensure workflows run without failures.
- https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/