### PR TITLE
Fixed wrangler version at 4.14.4

### DIFF
--- a/.github/workflows/continuous-benchmarking-baseline.yml
+++ b/.github/workflows/continuous-benchmarking-baseline.yml
@@ -304,7 +304,7 @@ jobs:
           node-version: 18
 
       - name: Install Cloudflare Wrangler
-        run: npm install -g wrangler
+        run: npm install -g wrangler@4.14.4
       
       - name: Download client artifact
         uses: actions/download-artifact@v4
@@ -732,7 +732,7 @@ jobs:
           node-version: 18
 
       - name: Install Cloudflare Wrangler
-        run: npm install -g wrangler
+        run: npm install -g wrangler@4.14.4
         
       - name: Download client artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -166,7 +166,7 @@ jobs:
         run: npm install -g serverless@3.38.0 serverless-azure-functions functions-have-names serverless-aliyun-function-compute
 
       - name: Install Cloudflare Wrangler
-        run: npm install -g wrangler
+        run: npm install -g wrangler@4.14.4
 
       - name: Download client artifact
         uses: actions/download-artifact@v4
@@ -346,7 +346,7 @@ jobs:
           node-version: 18
 
       - name: Install Cloudflare Wrangler
-        run: npm install -g wrangler
+        run: npm install -g wrangler@4.14.4
 
       - name: Download client artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This modification should fix the error "Wrangler requires at least Node.js v20.0.0. You are using v18.20.8. Please update your version of Node.js.".

Fixing wrangler at version 4.14.4 should allow the use of Node.js 18.20.8.